### PR TITLE
Fix TypeError when dynamic_depth="truncnorm" by using rvs() instead of rvs(1)

### DIFF
--- a/kermt/model/layers.py
+++ b/kermt/model/layers.py
@@ -262,7 +262,7 @@ class MPNEncoder(nn.Module):
                 lower = mu - 3 * sigma
                 upper = mu + 3 * sigma
                 X = stats.truncnorm((lower - mu) / sigma, (upper - mu) / sigma, loc=mu, scale=sigma)
-                ndepth = int(X.rvs(1))
+                ndepth = int(X.rvs())
         else:
             ndepth = self.depth
 


### PR DESCRIPTION
scipy's truncnorm.rvs(1) returns a 1-d NumPy array, which int() cannot convert to a scalar. Using rvs() without a size argument returns a scalar directly.