### PR TITLE
Disallow inconsistent usage of finetune and predict workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ python main.py predict \
     --data_path tests/data/finetune/test.csv \
     --checkpoint_dir path/to/finetuned_model/ \
     --no_features_scaling \
+    --features_generator rdkit_2d_normalized_cuik_molmaker \
     --output path/to/predictions.csv
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,5 @@ dependencies:
   - optuna
   - scikit-learn
   - tensorboard
-  - setuptools>=80.0.0
+  - setuptools<82.0.0
   - protobuf>=5.29.5

--- a/kermt/util/parsing.py
+++ b/kermt/util/parsing.py
@@ -85,6 +85,10 @@ def add_predict_args(parser: ArgumentParser):
     parser.add_argument('--seed', type=int, default=0, help='Random seed for prediction')
     parser.add_argument('--no_features_scaling', action='store_true', default=False,
                         help='Turn off scaling of features')
+    parser.add_argument('--rdkit2D_normalization_type', type=str, choices=("fast", "best", "descriptastorus"), default='fast',
+                        help='Type of normalization for rdkit2D features. Choices: fast, best, descriptastorus')
+    parser.add_argument('--use_cuikmolmaker_featurization', action='store_true', default=False,
+                        help='Use cuik-molmaker package for featurization of atoms and bonds in molecules')
 
 
 def add_fingerprint_args(parser):

--- a/kermt/util/utils.py
+++ b/kermt/util/utils.py
@@ -691,7 +691,8 @@ def create_logger(name: str, save_dir: str = None, quiet: bool = False) -> loggi
 def load_checkpoint(path: str,
                     current_args: Namespace = None,
                     cuda: bool = None,
-                    logger: logging.Logger = None):
+                    logger: logging.Logger = None,
+                    strict_shape_check: bool = True):
     """
     Loads a model checkpoint.
 
@@ -699,6 +700,7 @@ def load_checkpoint(path: str,
     :param current_args: The current arguments. Replaces the arguments loaded from the checkpoint if provided.
     :param cuda: Whether to move model to cuda.
     :param logger: A logger.
+    :param strict_shape_check: Whether to check if the shape of the loaded model parameters matches the shape of the model parameters.
     :return: The loaded MPNN.
     """
     debug = logger.debug if logger is not None else print
@@ -731,9 +733,12 @@ def load_checkpoint(path: str,
         if new_param_name not in model_state_dict:
             debug(f'Pretrained parameter "{param_name}" cannot be found in model parameters.')
         elif model_state_dict[new_param_name].shape != loaded_state_dict[param_name].shape:
-            debug(f'Pretrained parameter "{param_name}" '
-                  f'of shape {loaded_state_dict[param_name].shape} does not match corresponding '
-                  f'model parameter of shape {model_state_dict[new_param_name].shape}.')
+            if strict_shape_check:
+                raise ValueError(f'Pretrained parameter "{param_name}" of shape {loaded_state_dict[param_name].shape} does not match corresponding model parameter of shape {model_state_dict[new_param_name].shape}.')
+            else:
+                debug(f'Pretrained parameter "{param_name}" '
+                    f'of shape {loaded_state_dict[param_name].shape} does not match corresponding '
+                    f'model parameter of shape {model_state_dict[new_param_name].shape}.')
         else:
             debug(f'Loading pretrained parameter "{param_name}".')
             pretrained_state_dict[new_param_name] = loaded_state_dict[param_name]

--- a/kermt/util/utils.py
+++ b/kermt/util/utils.py
@@ -75,6 +75,13 @@ def get_model_args():
             'dist_coff', 'no_attach_fea', 'coord', "num_attn_head", "num_mt_block",
             ]
 
+def get_finetune_predict_consistency_args():
+    """
+    Get the arguments that should be consistent between finetune and predict modes.
+    :return: a list containing parameters
+    """
+    return ['rdkit2D_normalization_type', 'features_generator']
+
 
 def save_features(path: str, features: List[np.ndarray]):
     """
@@ -744,6 +751,71 @@ def load_checkpoint(path: str,
             pretrained_state_dict[new_param_name] = loaded_state_dict[param_name]
     # Load pretrained weights
     model_state_dict.update(pretrained_state_dict)
+    model.load_state_dict(model_state_dict)
+
+    if cuda:
+        debug('Moving model to cuda')
+        model = model.cuda()
+
+    return model
+
+
+def load_checkpoint_for_prediction(path: str,
+                    current_args: Namespace,
+                    cuda: bool = None,
+                    logger: logging.Logger = None):
+    """
+    Loads a model checkpoint.
+
+    :param path: Path where checkpoint is saved.
+    :param current_args: The current arguments. Replaces the arguments loaded from the checkpoint if provided.
+    :param cuda: Whether to move model to cuda.
+    :param logger: A logger.
+    :return: The loaded MPNN.
+    """
+    debug = logger.debug if logger is not None else print
+
+    # Load model and args
+    # TODO(sveccham): Change this to weights_only=True
+    state = torch.load(path, map_location=lambda storage, loc: storage, weights_only=False)
+    loaded_args, loaded_state_dict = state['args'], state['state_dict']
+
+    loaded_state_dict = OrderedDict([(k.replace("grover", "kermt"), v) for k, v in loaded_state_dict.items()])
+
+    # Check for consistency between finetune and predict arguments
+    # ensuring that the model is used exactly how it was finetuned.
+    finetune_predict_consistency_args = get_finetune_predict_consistency_args()
+    for key, value in vars(current_args).items():
+        if key in finetune_predict_consistency_args:
+            if value != vars(loaded_args)[key]:
+                raise ValueError(f'Argument {key} is not consistent between finetune and predict. '
+                                 f'Finetune value: {value}, Predict value: {vars(loaded_args)[key]}')
+
+    model_related_args = get_model_args()
+    for key, value in vars(loaded_args).items():
+        if key in model_related_args:
+            setattr(current_args, key, value)
+
+    # Build model
+    model = build_model(current_args)
+    model_state_dict = model.state_dict()
+
+    # Load finetuned weights
+    # Do not skip missing parameters
+    # All parameters should have consistent size
+    finetuned_state_dict = {}
+    for param_name in loaded_state_dict.keys():
+        new_param_name = param_name
+        if new_param_name not in model_state_dict:
+            raise ValueError(f'Pretrained parameter "{param_name}" cannot be found in model parameters.')
+        elif model_state_dict[new_param_name].shape != loaded_state_dict[param_name].shape:
+            # Shape checking should always be strict
+            raise ValueError(f'Pretrained parameter "{param_name}" of shape {loaded_state_dict[param_name].shape} does not match corresponding model parameter of shape {model_state_dict[new_param_name].shape}.')
+        else:
+            debug(f'Loading pretrained parameter "{param_name}".')
+            finetuned_state_dict[new_param_name] = loaded_state_dict[param_name]
+    # Load pretrained weights
+    model_state_dict.update(finetuned_state_dict)
     model.load_state_dict(model_state_dict)
 
     if cuda:

--- a/task/predict.py
+++ b/task/predict.py
@@ -50,7 +50,7 @@ from kermt.data import MolCollator
 from kermt.data import MoleculeDataset
 from kermt.data import StandardScaler
 from kermt.util.utils import get_data, get_data_from_smiles, create_logger, load_args, get_task_names, tqdm, \
-    load_checkpoint, load_scalars
+    load_checkpoint_for_prediction, load_scalars
 
 
 def predict(model: nn.Module,
@@ -189,7 +189,7 @@ def make_predictions(args: Namespace, newest_train_args=None, smiles: List[str] 
     count = 0
     for checkpoint_path in tqdm(args.checkpoint_paths, total=len(args.checkpoint_paths)):
         # Load model
-        model = load_checkpoint(checkpoint_path, cuda=args.cuda, current_args=args, logger=logger)
+        model = load_checkpoint_for_prediction(checkpoint_path, cuda=args.cuda, current_args=args, logger=logger)
         model_preds, _ = predict(
             model=model,
             data=test_data,

--- a/task/predict.py
+++ b/task/predict.py
@@ -81,7 +81,6 @@ def predict(model: nn.Module,
     loss_sum, iter_count = 0, 0
 
     mol_collator = MolCollator(args=args, shared_dict=shared_dict)
-    # mol_dataset = MoleculeDataset(data)
 
     num_workers = 0
     mol_loader = DataLoader(data, batch_size=batch_size, shuffle=False, num_workers=num_workers,


### PR DESCRIPTION
This PR fixes inconsistent usage of finetune and predict workflows. 

### First inconsistent usage pattern
1. Finetune with `--rdkit2D_normalization_type descriptastorus`
`python main.py finetune \
     --data_path tests/data/finetune/train.csv \
     --separate_val_path tests/data/finetune/val.csv \
     --separate_test_path tests/data/finetune/test.csv \
     --save_dir test_run/finetune \
     --checkpoint_path ~/path/to/pretrained.pt \
     --dataset_type regression --split_type scaffold_balanced \
     --ensemble_size 1 --num_folds 1 --no_features_scaling \
     --ffn_hidden_size 700 --ffn_num_layers 3 --bond_drop_rate 0.1 \
     --epochs 4 --metric mae --self_attention --dist_coff 0.15 \
     --max_lr 1e-4 --final_lr 2e-5 --dropout 0.0 \
     --use_cuikmolmaker_featurization \
     --features_generator rdkit_2d_normalized_cuik_molmaker \
     --rdkit2D_normalization_type descriptastorus --seed 50
 `
2. Incorrectly predict with ` --rdkit2D_normalization_type fast`
`python main.py predict      --data_path tests/data/finetune/test.csv      --checkpoint_dir test_run/finetune/      --no_features_scaling      --features_generator rdkit_2d_normalized_cuik_molmaker      --rdkit2D_normalization_type fast      --output test_run/predict_inconsistent/predict.csv`
This usage is disallowed:
`ValueError: Argument rdkit2D_normalization_type is not consistent between finetune and predict. Finetune value: fast, Predict value: descriptastorus`

### Second inconsistent usage pattern
1. Finetune with `--features_generator rdkit_2d_normalized_cuik_molmaker`
`python main.py finetune \
     --data_path tests/data/finetune/train.csv \
     --separate_val_path tests/data/finetune/val.csv \
     --separate_test_path tests/data/finetune/test.csv \
     --save_dir test_run/finetune \
     --checkpoint_path ~/path/to/pretrained.pt \
     --dataset_type regression --split_type scaffold_balanced \
     --ensemble_size 1 --num_folds 1 --no_features_scaling \
     --ffn_hidden_size 700 --ffn_num_layers 3 --bond_drop_rate 0.1 \
     --epochs 4 --metric mae --self_attention --dist_coff 0.15 \
     --max_lr 1e-4 --final_lr 2e-5 --dropout 0.0 \
     --use_cuikmolmaker_featurization \
     --features_generator rdkit_2d_normalized_cuik_molmaker \
     --rdkit2D_normalization_type descriptastorus --seed 50`
2. Predict without `--features_generator rdkit_2d_normalized_cuik_molmaker`
`python main.py predict      --data_path tests/data/finetune/test.csv      --checkpoint_dir test_run/finetune/      --no_features_scaling      --rdkit2D_normalization_type descriptastorus      --output test_run/predict_inconsistent/predict.csv`
Disallows inconsistent usage
`    raise ValueError(f'Argument {key} is not consistent between finetune and predict. '
ValueError: Argument features_generator is not consistent between finetune and predict. Finetune value: None, Predict value: ['rdkit_2d_normalized_cuik_molmaker']`

### Pin `setuptools`
Pin `setuptools<82.0.0` for `pkg_resources` 
