### PR TITLE
Fix checkpoint handling, validation, and training robustness

### DIFF
--- a/kermt/data/molgraph.py
+++ b/kermt/data/molgraph.py
@@ -159,6 +159,10 @@ class MolGraph:
         # Convert smiles to molecule
         mol = Chem.MolFromSmiles(smiles)
 
+        # Check if SMILES is valid
+        if mol is None:
+            raise ValueError(f"Invalid SMILES string: '{smiles}'. RDKit failed to parse it.")
+
         # fake the number of "atoms" if we are collapsing substructures
         self.n_atoms = mol.GetNumAtoms()
         self.n_rdkit_bonds = mol.GetNumBonds() # number of bonds in rdkit molecule (without considering bond drop rate)

--- a/kermt/data/torchvocab.py
+++ b/kermt/data/torchvocab.py
@@ -84,7 +84,7 @@ class TorchVocab(object):
         return (seq, len(seq)) if with_len else seq
 
     @staticmethod
-    def load_vocab(vocab_path: str) -> 'Vocab':
+    def load_vocab(vocab_path: str) -> 'TorchVocab':
         with open(vocab_path, "rb") as f:
             return pickle.load(f)
 
@@ -173,6 +173,9 @@ class MolVocab(TorchVocab):
             if i >= end:
                 break
             mol = Chem.MolFromSmiles(smi)
+            # Skip invalid molecules (RDKit returns None for invalid SMILES)
+            if mol is None:
+                continue
             if vocab_type == 'atom':
                 for atom in mol.GetAtoms():
                     v = atom_to_vocab(mol, atom)

--- a/kermt/model/models.py
+++ b/kermt/model/models.py
@@ -463,7 +463,8 @@ class KermtFinetuneTask(nn.Module):
 
         dropout = nn.Dropout(args.dropout)
         activation = get_activation_function(args.activation)
-        # TODO: ffn_hidden_size
+        # Default ffn_hidden_size to hidden_size if not specified
+        ffn_hidden_size = args.ffn_hidden_size if args.ffn_hidden_size is not None else args.hidden_size
         # Create FFN layers
         if args.ffn_num_layers == 1:
             ffn = [
@@ -473,18 +474,18 @@ class KermtFinetuneTask(nn.Module):
         else:
             ffn = [
                 dropout,
-                nn.Linear(first_linear_dim, args.ffn_hidden_size)
+                nn.Linear(first_linear_dim, ffn_hidden_size)
             ]
             for _ in range(args.ffn_num_layers - 2):
                 ffn.extend([
                     activation,
                     dropout,
-                    nn.Linear(args.ffn_hidden_size, args.ffn_hidden_size),
+                    nn.Linear(ffn_hidden_size, ffn_hidden_size),
                 ])
             ffn.extend([
                 activation,
                 dropout,
-                nn.Linear(args.ffn_hidden_size, args.output_size),
+                nn.Linear(ffn_hidden_size, args.output_size),
             ])
 
         # Create FFN model

--- a/kermt/util/nn_utils.py
+++ b/kermt/util/nn_utils.py
@@ -7,13 +7,21 @@ import torch
 from torch import nn as nn
 
 
-def param_count(model: nn.Module) -> int:
+def param_count_trainable(model: nn.Module) -> int:
     """
     Determines number of trainable parameters.
     :param model: An nn.Module.
     :return: The number of trainable parameters.
     """
     return sum(param.numel() for param in model.parameters() if param.requires_grad)
+
+def param_count_total(model: nn.Module) -> int:
+    """
+    Determines total number of parameters.
+    :param model: An nn.Module.
+    :return: The number of total parameters.
+    """
+    return sum(param.numel() for param in model.parameters())
 
 
 def index_select_nd(source: torch.Tensor, index: torch.Tensor) -> torch.Tensor:

--- a/kermt/util/nn_utils.py
+++ b/kermt/util/nn_utils.py
@@ -69,15 +69,22 @@ def get_activation_function(activation: str) -> nn.Module:
         raise ValueError(f'Activation "{activation}" not supported.')
 
 
-def initialize_weights(model: nn.Module, distinct_init=False, model_idx=0):
+def initialize_weights(model: nn.Module, distinct_init=False, model_idx=0, init_param_names=None):
     """
     Initializes the weights of a model in place.
 
     :param model: An nn.Module.
+    :param distinct_init: Whether to use distinct initialization for different models in the ensemble.
+    :param model_idx: The index of the model.
+    :param init_param_names: The names of the parameters to initialize. If None, no parameters will be initialized.
     """
+    if init_param_names is None:
+        init_param_names = []
     init_fns = [nn.init.kaiming_normal_, nn.init.kaiming_uniform_,
                nn.init.xavier_normal_, nn.init.xavier_uniform_]
-    for param in model.parameters():
+    for name, param in model.state_dict().items():
+        if name not in init_param_names:
+            continue
         if param.dim() == 1:
             nn.init.constant_(param, 0)
         else:

--- a/kermt/util/parsing.py
+++ b/kermt/util/parsing.py
@@ -255,8 +255,8 @@ def add_finetune_args(parser: ArgumentParser):
                                                                                      'layer.')
     parser.add_argument('--attn_hidden', type=int, default=4, nargs='?', help='Self attention layer '
                                                                               'hidden layer size.')
-    parser.add_argument('--attn_out', type=int, default=128, nargs='?', help='Self attention layer '
-                                                                             'output feature size.')
+    parser.add_argument('--attn_out', type=int, default=8, nargs='?', help='Self attention layer '
+                                                                             'output feature size (FFN input = hidden_size * attn_out).')
 
     parser.add_argument('--dist_coff', type=float, default=0.1, help='The dist coefficient for output of two branches.')
 

--- a/kermt/util/parsing.py
+++ b/kermt/util/parsing.py
@@ -237,6 +237,20 @@ def add_finetune_args(parser: ArgumentParser):
     parser.add_argument('--activation', type=str, default='ReLU',
                         choices=['ReLU', 'LeakyReLU', 'PReLU', 'tanh', 'SELU', 'ELU'],
                         help='Activation function')
+    # Encoder architecture arguments (required when training from scratch without checkpoint)
+    parser.add_argument('--hidden_size', type=int, default=800,
+                        help='Encoder hidden dimension. Default: 800 (matches pretrained models)')
+    parser.add_argument('--depth', type=int, default=6,
+                        help='Number of encoder message passing layers. Default: 6')
+    parser.add_argument('--num_attn_head', type=int, default=4,
+                        help='Number of attention heads in encoder MTBlock. Default: 4')
+    parser.add_argument('--num_mt_block', type=int, default=1,
+                        help='Number of MTBlocks in encoder. Default: 1')
+    parser.add_argument('--bias', action='store_true', default=False,
+                        help='Whether to add bias to encoder linear layers. Default: False')
+    parser.add_argument('--undirected', action='store_true', default=False,
+                        help='Use undirected edges (sum the two relevant bond vectors). Default: False')
+
     parser.add_argument('--ffn_hidden_size', type=int, default=None,
                         help='Hidden dim for higher-capacity FFN (defaults to hidden_size)')
     parser.add_argument('--ffn_num_layers', type=int, default=2,
@@ -507,6 +521,9 @@ def modify_train_args(args: Namespace):
         args.no_cache = True
 
     setattr(args, 'fingerprint', False)
+
+    # Set dense=False for encoder (required when training from scratch)
+    args.dense = False
 
 
 def modify_pretrain_args(args: Namespace):

--- a/kermt/util/scheduler.py
+++ b/kermt/util/scheduler.py
@@ -58,7 +58,7 @@ class NoamLR(_LRScheduler):
         self.init_lr = np.array([init_lr] * self.num_lrs)
         self.max_lr = np.array([max_lr] * self.num_lrs)
         self.final_lr = np.array([final_lr] * self.num_lrs)
-        self.lr_coff = np.array([1] * self.num_lrs)
+        self.lr_coff = np.array([1.0] * self.num_lrs, dtype=float)
         self.fine_tune_param_idx = fine_tune_param_idx
         self.lr_coff[self.fine_tune_param_idx] = fine_tune_coff
 

--- a/kermt/util/utils.py
+++ b/kermt/util/utils.py
@@ -896,6 +896,31 @@ def save_checkpoint(path: str,
     torch.save(state, path)
 
 
+def save_model_for_restart(path:str, model, optimizer, scheduler, scaler, features_scaler, args, epoch):
+    """
+    Save the model, optimizer, and scheduler for restart. Saves model state_dict, optimizer state_dict, scheduler state_dict, data_scaler, features_scaler, and args.
+    """
+    # checkpoint_path is the path for pretrained model. It is not needed to restart finetuning.
+    if hasattr(args, 'checkpoint_path'):
+        delattr(args, 'checkpoint_path')
+    state = {
+        'args': args,
+        'epoch': epoch,
+        'state_dict': model.state_dict(),
+        'optimizer': optimizer.state_dict(),
+        'scheduler': scheduler.state_dict(),
+        'data_scaler': {
+            'means': scaler.means,
+            'stds': scaler.stds
+        } if scaler is not None else None,
+        'features_scaler': {
+            'means': features_scaler.means,
+            'stds': features_scaler.stds
+        } if features_scaler is not None else None
+    }
+    torch.save(state, path)
+
+
 def build_model(args: Namespace, model_idx=0):
     """
     Builds a MPNN, which is a message passing neural network + feed-forward layers.

--- a/kermt/util/utils.py
+++ b/kermt/util/utils.py
@@ -63,16 +63,22 @@ from kermt.util.scheduler import NoamLR
 
 def get_model_args():
     """
-    Get model structure related parameters
+    Get model structure related parameters.
+
+    Note: 'attn_out' is intentionally excluded. It controls the self-attention readout
+    output size (FFN input = hidden_size * attn_out) and is only used during finetuning.
+    Old checkpoints may have attn_out=128 saved, which causes model size to blow up.
+    By excluding it, we allow the command-line/default value to take precedence.
 
     :return: a list containing parameters
     """
     return ['model_type', 'ensemble_size', 'input_layer', 'hidden_size', 'bias', 'depth',
             'dropout', 'activation', 'undirected', 'ffn_hidden_size', 'ffn_num_layers',
             'atom_message', 'weight_decay', 'select_by_loss', 'skip_epoch', 'backbone',
-            'embedding_output_type', 'self_attention', 'attn_hidden', 'attn_out', 'dense',
-            'bond_drop_rate', 'distinct_init', 'aug_rate', 'fine_tune_coff', 'nencoders',
+            'embedding_output_type', 'self_attention', 'attn_hidden', 'dense',
+            'bond_drop_rate', 'distinct_init', 'aug_rate', 'nencoders',
             'dist_coff', 'no_attach_fea', 'coord', "num_attn_head", "num_mt_block",
+            'num_tasks',  # Required for prediction on blinded data (no target columns)
             ]
 
 def get_finetune_predict_consistency_args():
@@ -708,7 +714,7 @@ def load_checkpoint(path: str,
     :param cuda: Whether to move model to cuda.
     :param logger: A logger.
     :param strict_shape_check: Whether to check if the shape of the loaded model parameters matches the shape of the model parameters.
-    :return: The loaded MPNN.
+    :return: The loaded MPNN and loaded checkpoint state.
     """
     debug = logger.debug if logger is not None else print
 
@@ -757,7 +763,7 @@ def load_checkpoint(path: str,
         debug('Moving model to cuda')
         model = model.cuda()
 
-    return model
+    return model, state
 
 
 def load_checkpoint_for_prediction(path: str,

--- a/kermt/util/utils.py
+++ b/kermt/util/utils.py
@@ -39,6 +39,7 @@ The general utility functions.
 """
 import csv
 import logging
+import math
 import os
 import pickle
 import random
@@ -602,13 +603,14 @@ def load_args(path: str) -> Namespace:
 
 
 
-def get_ffn_layer_id(model: KermtFinetuneTask):
+def get_ffn_layer_names(model: KermtFinetuneTask):
     """
     Get the ffn layer id for KermtFinetune Task. (Adhoc!)
     :param model:
     :return:
     """
-    return [id(x) for x in model.state_dict() if "kermt" not in x and "ffn" in x]
+    # Readout and atom/bond ffn layers are returned
+    return [name for name, _ in model.named_parameters() if "kermt" not in name]
 
 
 def build_optimizer(model: nn.Module, args: Namespace):
@@ -622,15 +624,19 @@ def build_optimizer(model: nn.Module, args: Namespace):
 
     # Only adjust the learning rate for the KermtFinetuneTask.
     if type(model) == KermtFinetuneTask:
-        ffn_params = get_ffn_layer_id(model)
+        ffn_param_names = get_ffn_layer_names(model)
     else:
         # if not, init adam optimizer normally.
         return torch.optim.Adam(model.parameters(), lr=args.init_lr, weight_decay=args.weight_decay)
-    base_params = filter(lambda p: id(p) not in ffn_params, model.parameters())
-    ffn_params = filter(lambda p: id(p) in ffn_params, model.parameters())
-    if args.fine_tune_coff == 0:
+    base_params = [param for k, param in model.named_parameters() if k not in ffn_param_names]
+    ffn_params = [param for k, param in model.named_parameters() if k in ffn_param_names]
+    print(f"Number of base params: {len(base_params)}, number of ffn params: {len(ffn_params)}")
+    if math.isclose(args.fine_tune_coff, 0.0, abs_tol=1e-6):
+        print("Freezing parameters of encoder")
         for param in base_params:
             param.requires_grad = False
+    else:
+        print("Not freezing parameters of encoder")
 
     optimizer = torch.optim.Adam([
         {'params': base_params, 'lr': args.init_lr * args.fine_tune_coff},
@@ -938,7 +944,8 @@ def build_model(args: Namespace, model_idx=0):
     else:
         # finetune and evaluation case.
         model = KermtFinetuneTask(args)
-    initialize_weights(model=model, model_idx=model_idx)
+    all_param_names = [name for name, _ in model.named_parameters()]
+    initialize_weights(model=model, model_idx=model_idx, init_param_names=all_param_names)
     return model
 
 def get_memory_usage():

--- a/pretrain_ddp.py
+++ b/pretrain_ddp.py
@@ -41,6 +41,44 @@ from kermt.data.kermtdataset import BatchMolDataset
 from kermt.util.parsing import parse_args_ddp
 from kermt.util.nn_utils import param_count
 
+
+def configure_nccl_for_topology():
+    """
+    Auto-configure NCCL settings based on GPU topology.
+    This handles cases where P2P (peer-to-peer) GPU communication is not available.
+    Must be called BEFORE spawning processes (in main process).
+    """
+    # Check if user has already set NCCL settings (don't override)
+    if "NCCL_P2P_DISABLE" in os.environ:
+        print(f"[INFO] Using user-provided NCCL settings: NCCL_P2P_DISABLE={os.environ['NCCL_P2P_DISABLE']}")
+        return
+
+    # Try to detect GPU topology
+    try:
+        import subprocess
+        result = subprocess.run(['nvidia-smi', 'topo', '-m'],
+                              capture_output=True, text=True, timeout=5)
+        topo_output = result.stdout
+
+        # Check for poor GPU connectivity (SYS or NODE topology)
+        # These topologies typically don't support P2P well
+        if 'SYS' in topo_output or 'NODE' in topo_output:
+            print("[INFO] Detected cross-NUMA or system-level GPU topology (SYS/NODE).")
+            print("[INFO] Disabling P2P for stability. This is normal for multi-socket systems.")
+            os.environ["NCCL_P2P_DISABLE"] = "1"
+            os.environ["NCCL_IB_DISABLE"] = "1"
+            os.environ["NCCL_SHM_DISABLE"] = "0"
+        else:
+            print("[INFO] GPU topology appears to support P2P. Enabling P2P communication.")
+    except Exception as e:
+        # If detection fails, use safe defaults (disable P2P)
+        print(f"[WARNING] Could not detect GPU topology: {e}")
+        print("[INFO] Using safe default: P2P disabled. Set NCCL_P2P_DISABLE=0 to enable if your system supports it.")
+        os.environ["NCCL_P2P_DISABLE"] = "1"
+        os.environ["NCCL_IB_DISABLE"] = "1"
+        os.environ["NCCL_SHM_DISABLE"] = "0"
+
+
 def pre_load_data_ddp(dataset: BatchMolDataset, dataset_size: int, samples_per_file: int):
     for i in range(1, dataset_size, samples_per_file):
         dataset.load_data(i)
@@ -176,6 +214,10 @@ def main(rank: int, world_size: int):
 
 
 if __name__ == "__main__":
+
+    # Auto-configure NCCL before spawning processes
+    # This detects GPU topology and sets appropriate P2P settings
+    configure_nccl_for_topology()
 
     world_size = os.environ.get("WORLD_SIZE", 1)
     world_size = int(world_size)

--- a/pretrain_ddp.py
+++ b/pretrain_ddp.py
@@ -39,7 +39,7 @@ from task.kermttrainer import KERMTTrainer
 from kermt.data.torchvocab import MolVocab
 from kermt.data.kermtdataset import BatchMolDataset
 from kermt.util.parsing import parse_args_ddp
-from kermt.util.nn_utils import param_count
+from kermt.util.nn_utils import param_count_trainable, param_count_total
 
 
 def configure_nccl_for_topology():
@@ -175,7 +175,8 @@ def main(rank: int, world_size: int):
     # Build model
     kermt_model = KERMTEmbedding(args)
 
-    print(f'Number of parameters = {param_count(kermt_model):,}')
+    print(f'Number of trainable parameters = {param_count_trainable(kermt_model):,}')
+    print(f'Number of total parameters = {param_count_total(kermt_model):,}')
 
     # Build trainer
     trainer = KERMTTrainer(args=args,

--- a/scripts/split_data.py
+++ b/scripts/split_data.py
@@ -56,13 +56,20 @@ def run():
     n_graphs = len(res)
     perm = np.random.permutation(n_graphs)
 
-    nfold = int(n_graphs / args.sample_per_file + 1)
+    nfold = (n_graphs + args.sample_per_file - 1) // args.sample_per_file
     print("Number of files: %d" % nfold)
-    if os.path.exists(args.output_path):
-        shutil.rmtree(args.output_path)
+
+    # Create output directory structure
     os.makedirs(args.output_path, exist_ok=True)
     graph_path = os.path.join(args.output_path, "graph")
     fea_path = os.path.join(args.output_path, "feature")
+
+    # Only remove the specific subdirectories we'll recreate
+    if os.path.exists(graph_path):
+        shutil.rmtree(graph_path)
+    if os.path.exists(fea_path):
+        shutil.rmtree(fea_path)
+
     os.makedirs(graph_path, exist_ok=True)
     os.makedirs(fea_path, exist_ok=True)
 

--- a/task/cross_validate.py
+++ b/task/cross_validate.py
@@ -40,12 +40,14 @@ This implementation is adapted from
 https://github.com/chemprop/chemprop/blob/master/chemprop/train/cross_validate.py
 """
 import os
+import random
 import time
 from argparse import Namespace
 from logging import Logger
 from typing import Tuple
 
 import numpy as np
+import torch
 
 from kermt.util.utils import get_task_names
 from kermt.util.utils import makedirs
@@ -73,6 +75,14 @@ def cross_validate(args: Namespace, logger: Logger = None) -> Tuple[float, float
         args.seed = init_seed + fold_num
         args.save_dir = os.path.join(save_dir, f'fold_{fold_num}')
         makedirs(args.save_dir)
+
+        # Reset random seeds for this fold to ensure different model initialization
+        # This is important when using separate train/val/test paths (no data splitting)
+        # so that each fold produces a model with different random weight initialization
+        torch.manual_seed(args.seed)
+        torch.cuda.manual_seed_all(args.seed)
+        np.random.seed(args.seed)
+        random.seed(args.seed)
         if args.parser_name == "finetune":
             model_scores = run_training(args, logger)
         else:

--- a/task/kermttrainer.py
+++ b/task/kermttrainer.py
@@ -367,10 +367,17 @@ class KERMTTrainer:
                 'stds': features_scaler.stds
             } if features_scaler is not None else None
         }
-        torch.save(state, output_path)
+        # Use atomic save pattern: write to .tmp then rename
+        # This prevents corrupted checkpoints if the process is killed mid-write
+        tmp_output_path = output_path + ".tmp"
+        torch.save(state, tmp_output_path)
+        os.replace(tmp_output_path, output_path)  # atomic on POSIX
+
         if save_last:
             last_path = os.path.join(file_path, "last_checkpoint.pt")
-            torch.save(state, last_path)
+            tmp_last_path = last_path + ".tmp"
+            torch.save(state, tmp_last_path)
+            os.replace(tmp_last_path, last_path)  # atomic on POSIX
 
         # Is this necessary?
         # if self.with_cuda:

--- a/task/predict.py
+++ b/task/predict.py
@@ -148,7 +148,8 @@ def make_predictions(args: Namespace, newest_train_args=None, smiles: List[str] 
 
     logger = create_logger('predict', quiet=False)
     print('Loading data')
-    args.task_names = get_task_names(args.data_path)
+    # Use task_names from checkpoint for blinded test data (no target columns)
+    args.task_names = train_args.task_names if hasattr(train_args, 'task_names') else get_task_names(args.data_path)
     if smiles is not None:
         test_data = get_data_from_smiles(smiles=smiles, skip_invalid_smiles=False)
     else:
@@ -180,8 +181,9 @@ def make_predictions(args: Namespace, newest_train_args=None, smiles: List[str] 
             test_data.normalize_features(features_scaler)
 
     # Predict with each model individually and sum predictions
-    if hasattr(args, 'num_tasks'):
-        sum_preds = np.zeros((len(test_data), args.num_tasks))
+    # Use train_args.num_tasks since args.num_tasks may be 0 for blinded test data
+    num_tasks = train_args.num_tasks if hasattr(train_args, 'num_tasks') else args.num_tasks
+    sum_preds = np.zeros((len(test_data), num_tasks))
     print(f'Predicting...')
     shared_dict = {}
     # loss_func = torch.nn.BCEWithLogitsLoss()

--- a/task/run_evaluation.py
+++ b/task/run_evaluation.py
@@ -14,7 +14,7 @@ from kermt.util.utils import get_class_sizes, get_data, split_data, get_task_nam
 from kermt.util.utils import load_checkpoint
 from task.predict import evaluate_predictions
 from kermt.util.metrics import get_metric_func
-from kermt.util.nn_utils import param_count
+from kermt.util.nn_utils import param_count_trainable, param_count_total
 from task.predict import predict
 
 
@@ -101,7 +101,7 @@ def run_evaluation(args: Namespace, logger: Logger = None) -> List[float]:
         # Get loss and metric functions
         loss_func = get_loss_func(args, model)
 
-    debug(f'Number of parameters = {param_count(model):,}')
+    debug(f'Number of total parameters = {param_count_total(model):,}')
 
     test_preds, _ = predict(
         model=model,

--- a/task/train.py
+++ b/task/train.py
@@ -55,7 +55,7 @@ from torch.utils.data import DataLoader
 from kermt.data import MolCollator
 from kermt.data import StandardScaler
 from kermt.util.metrics import get_metric_func
-from kermt.util.nn_utils import initialize_weights, param_count
+from kermt.util.nn_utils import initialize_weights, param_count_trainable, param_count_total
 from torch.utils.tensorboard import SummaryWriter
 from kermt.util.scheduler import NoamLR
 from kermt.util.utils import build_optimizer, build_lr_scheduler, makedirs, load_checkpoint, get_loss_func, \
@@ -201,7 +201,8 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
         optimizer = build_optimizer(model, args)
 
         debug(model)
-        debug(f'Number of parameters = {param_count(model):,}')
+        debug(f'Number of trainable parameters = {param_count_trainable(model):,}')
+        debug(f'Number of total parameters = {param_count_total(model):,}')
 
         start_epoch = 0  # Default: start from epoch 0
         # Try to load optimizer state - only use start_epoch if optimizer loads successfully

--- a/task/train.py
+++ b/task/train.py
@@ -59,7 +59,7 @@ from kermt.util.nn_utils import initialize_weights, param_count
 from torch.utils.tensorboard import SummaryWriter
 from kermt.util.scheduler import NoamLR
 from kermt.util.utils import build_optimizer, build_lr_scheduler, makedirs, load_checkpoint, get_loss_func, \
-    save_checkpoint, build_model
+    save_checkpoint, save_model_for_restart, build_model
 from kermt.util.utils import get_class_sizes, get_data, split_data, get_task_names
 from task.predict import predict, evaluate, evaluate_predictions
 
@@ -309,6 +309,9 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
             else:
                 curr_epoch_best_by_loss = False
 
+            save_model_for_restart(os.path.join(save_dir, 'last_checkpoint.pt'), model, optimizer, scheduler, scaler, features_scaler, args,
+            epoch+1 # save with +1 so that loaded checkpoint will start from the next epoch
+            )
             # Save model checkpoint if improved validation score
             if args.select_by_loss:
                 if curr_epoch_best_by_loss:

--- a/task/train.py
+++ b/task/train.py
@@ -56,6 +56,7 @@ from kermt.data import MolCollator
 from kermt.data import StandardScaler
 from kermt.util.metrics import get_metric_func
 from kermt.util.nn_utils import initialize_weights, param_count
+from torch.utils.tensorboard import SummaryWriter
 from kermt.util.scheduler import NoamLR
 from kermt.util.utils import build_optimizer, build_lr_scheduler, makedirs, load_checkpoint, get_loss_func, \
     save_checkpoint, build_model
@@ -167,11 +168,17 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
     test_smiles, test_targets = test_data.smiles(), test_data.targets()
     sum_test_preds = np.zeros((len(test_smiles), args.num_tasks))
 
+    # Check if test data is blinded (no target columns)
+    is_blinded_test = len(test_targets) == 0 or (len(test_targets) > 0 and len(test_targets[0]) == 0)
+
     # Train ensemble of models
     for model_idx in range(args.ensemble_size):
-        # Tensorboard writer
         save_dir = os.path.join(args.save_dir, f'model_{model_idx}')
         makedirs(save_dir)
+
+        # Initialize TensorBoard writer if enabled
+        if args.tensorboard:
+            writer = SummaryWriter(save_dir)
 
         # Load/build model
         if args.checkpoint_paths is not None:
@@ -180,10 +187,11 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
             else:
                 cur_model = model_idx
             debug(f'Loading model {cur_model} from {args.checkpoint_paths[cur_model]}')
-            model = load_checkpoint(args.checkpoint_paths[cur_model], current_args=args, logger=logger)
+            model, loaded_ckpt_state = load_checkpoint(args.checkpoint_paths[cur_model], current_args=args, logger=logger)
         else:
             debug(f'Building model {model_idx}')
             model = build_model(model_idx=model_idx, args=args)
+            loaded_ckpt_state = {}
         if args.fine_tune_coff != 1 and args.checkpoint_paths is not None:
             debug("Fine tune fc layer with different lr")
             initialize_weights(model_idx=model_idx, model=model.ffn, distinct_init=args.distinct_init)
@@ -194,6 +202,21 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
 
         debug(model)
         debug(f'Number of parameters = {param_count(model):,}')
+
+        start_epoch = 0  # Default: start from epoch 0
+        # Try to load optimizer state - only use start_epoch if optimizer loads successfully
+        # (indicates resuming a finetune job vs starting fresh from pretrain checkpoint)
+        if args.checkpoint_paths is not None and "optimizer" in loaded_ckpt_state:
+            try:
+                print(f"Loading optimizer state from checkpoint: {args.checkpoint_paths[cur_model]}")
+                optimizer.load_state_dict(loaded_ckpt_state["optimizer"])
+                # Only resume from checkpoint epoch if optimizer loaded successfully
+                if "epoch" in loaded_ckpt_state:
+                    start_epoch = loaded_ckpt_state["epoch"]
+                    print(f"Resuming from epoch {start_epoch}")
+            except ValueError as e:
+                print(f"Could not load optimizer state (model structure may differ): {e}")
+                print("Starting fresh finetuning from epoch 0.")
         if args.cuda:
             debug('Moving model to cuda')
             model = model.cuda()
@@ -203,6 +226,15 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
 
         # Learning rate schedulers
         scheduler = build_lr_scheduler(optimizer, args)
+
+        # Only load scheduler state if we're resuming (start_epoch > 0 means optimizer loaded successfully)
+        if start_epoch > 0 and "scheduler" in loaded_ckpt_state:
+            try:
+                print(f"Loading scheduler state from checkpoint: {args.checkpoint_paths[cur_model]}")
+                scheduler.load_state_dict(loaded_ckpt_state["scheduler"])
+            except (ValueError, KeyError) as e:
+                print(f"Could not load scheduler state: {e}")
+                print("Starting with fresh scheduler state.")
 
         # Bulid data_loader
         shuffle = True
@@ -216,7 +248,7 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
         best_score = float('inf') if args.minimize_score else -float('inf')
         best_epoch, n_iter = 0, 0
         min_val_loss = float('inf')
-        for epoch in range(args.epochs):
+        for epoch in range(start_epoch, args.epochs):
             s_time = time.time()
             n_iter, train_loss = train(
                 epoch=epoch,
@@ -297,12 +329,12 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
             info(f'Model {model_idx} best val loss = {min_val_loss:.6f} on epoch {best_epoch}')
         else:
             info(f'Model {model_idx} best validation {args.metric} = {best_score:.6f} on epoch {best_epoch}')
-        model = load_checkpoint(os.path.join(save_dir, 'model.pt'), cuda=args.cuda, logger=logger)
+        model, _ = load_checkpoint(os.path.join(save_dir, 'model.pt'), cuda=args.cuda, logger=logger)
 
         test_preds, _ = predict(
             model=model,
             data=test_data,
-            loss_func=loss_func,
+            loss_func=None if is_blinded_test else loss_func,  # Skip loss calc for blinded data
             batch_size=args.batch_size,
             logger=logger,
             shared_dict=shared_dict,
@@ -310,53 +342,68 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
             args=args
         )
 
-        test_scores = evaluate_predictions(
-            preds=test_preds,
-            targets=test_targets,
-            num_tasks=args.num_tasks,
-            metric_func=metric_func,
-            dataset_type=args.dataset_type,
-            logger=logger
-        )
-
         if len(test_preds) != 0:
             sum_test_preds += np.array(test_preds, dtype=float)
 
-        # Average test score
-        avg_test_score = np.nanmean(test_scores)
-        info(f'Model {model_idx} test {args.metric} = {avg_test_score:.6f}')
+        if not is_blinded_test:
+            test_scores = evaluate_predictions(
+                preds=test_preds,
+                targets=test_targets,
+                num_tasks=args.num_tasks,
+                metric_func=metric_func,
+                dataset_type=args.dataset_type,
+                logger=logger
+            )
 
-        if args.show_individual_scores:
-            # Individual test scores
-            for task_name, test_score in zip(args.task_names, test_scores):
-                info(f'Model {model_idx} test {task_name} {args.metric} = {test_score:.6f}')
+            # Average test score
+            avg_test_score = np.nanmean(test_scores)
+            info(f'Model {model_idx} test {args.metric} = {avg_test_score:.6f}')
+
+            if args.show_individual_scores:
+                # Individual test scores
+                for task_name, test_score in zip(args.task_names, test_scores):
+                    info(f'Model {model_idx} test {task_name} {args.metric} = {test_score:.6f}')
+        else:
+            info(f'Model {model_idx} test: Blinded data - skipping metric evaluation')
 
         # Evaluate ensemble on test set
         avg_test_preds = (sum_test_preds / args.ensemble_size).tolist()
 
-        ensemble_scores = evaluate_predictions(
-            preds=avg_test_preds,
-            targets=test_targets,
-            num_tasks=args.num_tasks,
-            metric_func=metric_func,
-            dataset_type=args.dataset_type,
-            logger=logger
-        )
+        if not is_blinded_test:
+            ensemble_scores = evaluate_predictions(
+                preds=avg_test_preds,
+                targets=test_targets,
+                num_tasks=args.num_tasks,
+                metric_func=metric_func,
+                dataset_type=args.dataset_type,
+                logger=logger
+            )
 
-        ind = [['preds'] * args.num_tasks + ['targets'] * args.num_tasks, args.task_names * 2]
-        ind = pd.MultiIndex.from_tuples(list(zip(*ind)))
-        data = np.concatenate([np.array(avg_test_preds), np.array(test_targets)], 1)
-        test_result = pd.DataFrame(data, index=test_smiles, columns=ind)
-        test_result.to_csv(os.path.join(args.save_dir, 'test_result.csv'))
+            # Output with both predictions and targets
+            ind = [['preds'] * args.num_tasks + ['targets'] * args.num_tasks, args.task_names * 2]
+            ind = pd.MultiIndex.from_tuples(list(zip(*ind)))
+            data = np.concatenate([np.array(avg_test_preds), np.array(test_targets)], 1)
+            test_result = pd.DataFrame(data, index=test_smiles, columns=ind)
+            test_result.to_csv(os.path.join(args.save_dir, 'test_result.csv'))
 
-        # Average ensemble score
-        avg_ensemble_test_score = np.nanmean(ensemble_scores)
-        info(f'Ensemble test {args.metric} = {avg_ensemble_test_score:.6f}')
+            # Average ensemble score
+            avg_ensemble_test_score = np.nanmean(ensemble_scores)
+            info(f'Ensemble test {args.metric} = {avg_ensemble_test_score:.6f}')
 
-        # Individual ensemble scores
-        if args.show_individual_scores:
-            for task_name, ensemble_score in zip(args.task_names, ensemble_scores):
-                info(f'Ensemble test {task_name} {args.metric} = {ensemble_score:.6f}')
+            # Individual ensemble scores
+            if args.show_individual_scores:
+                for task_name, ensemble_score in zip(args.task_names, ensemble_scores):
+                    info(f'Ensemble test {task_name} {args.metric} = {ensemble_score:.6f}')
+        else:
+            # Blinded test data - output predictions only
+            ensemble_scores = [float('nan')] * args.num_tasks
+            test_result = pd.DataFrame(avg_test_preds, index=test_smiles, columns=args.task_names)
+            test_result.to_csv(os.path.join(args.save_dir, 'test_result.csv'))
+            info(f'Ensemble test: Blinded data - predictions saved to test_result.csv')
+
+        # Close TensorBoard writer
+        if args.tensorboard:
+            writer.close()
 
     if return_val:
         return ensemble_scores, min_val_loss

--- a/task/train.py
+++ b/task/train.py
@@ -232,8 +232,12 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
                 print(f"Loading scheduler state from checkpoint: {args.checkpoint_paths[cur_model]}")
                 scheduler.load_state_dict(loaded_ckpt_state["scheduler"])
             except (ValueError, KeyError) as e:
-                print(f"Could not load scheduler state: {e}")
-                print("Starting with fresh scheduler state.")
+                raise RuntimeError(
+                    f"Failed to load scheduler state from checkpoint "
+                    f"{args.checkpoint_paths[cur_model]}: {e}. "
+                    f"Optimizer loaded successfully (start_epoch={start_epoch}) "
+                    f"but scheduler is incompatible — checkpoint may be corrupted."
+                ) from e
 
         # Bulid data_loader
         shuffle = True

--- a/task/train.py
+++ b/task/train.py
@@ -295,7 +295,7 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
                   'cur_lr: {:.5f}'.format(scheduler.get_lr()[-1]),
                   't_time: {:.4f}s'.format(t_time),
                   'v_time: {:.4f}s'.format(v_time),
-                  )
+                  flush=True)
 
             if args.tensorboard:
                 writer.add_scalar('loss/train', train_loss, epoch)

--- a/task/train.py
+++ b/task/train.py
@@ -201,6 +201,9 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
         debug(model)
         debug(f'Number of trainable parameters = {param_count_trainable(model):,}')
         debug(f'Number of total parameters = {param_count_total(model):,}')
+        if args.cuda:
+            debug('Moving model to cuda')
+            model = model.cuda()
 
         start_epoch = 0  # Default: start from epoch 0
         # Try to load optimizer state - only use start_epoch if optimizer loads successfully
@@ -216,9 +219,6 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
             except ValueError as e:
                 print(f"Could not load optimizer state (model structure may differ): {e}")
                 print("Starting fresh finetuning from epoch 0.")
-        if args.cuda:
-            debug('Moving model to cuda')
-            model = model.cuda()
 
         # Ensure that model is saved in correct location for evaluation if 0 epochs
         save_checkpoint(os.path.join(save_dir, 'model.pt'), model, scaler, features_scaler, args)

--- a/task/train.py
+++ b/task/train.py
@@ -192,9 +192,7 @@ def run_training(args: Namespace, logger: Logger = None, return_val=False) -> Li
             debug(f'Building model {model_idx}')
             model = build_model(model_idx=model_idx, args=args)
             loaded_ckpt_state = {}
-        if args.fine_tune_coff != 1 and args.checkpoint_paths is not None:
-            debug("Fine tune fc layer with different lr")
-            initialize_weights(model_idx=model_idx, model=model.ffn, distinct_init=args.distinct_init)
+
         # Get loss and metric functions
         loss_func = get_loss_func(args, model)
 

--- a/tests/unit/test_featurization.py
+++ b/tests/unit/test_featurization.py
@@ -26,7 +26,7 @@ import pytest
 import torch
 import pandas as pd
 from argparse import Namespace
-from kermt.data.molgraph import mol2graph
+from kermt.data.molgraph import MolGraph, mol2graph
 from kermt.util.features import get_feature_range
 
 import cuik_molmaker
@@ -78,3 +78,10 @@ def test_cuik_molmaker_featurization(bond_drop_rate: float):
     assert torch.allclose(a_scope, batch_mol_graph_ref['a_scope']), f"a_scope are not equal"
     assert torch.allclose(b_scope, batch_mol_graph_ref['b_scope']), f"b_scope are not equal"
     assert torch.allclose(a2a, batch_mol_graph_ref['a2a']), f"a2a are not equal"
+
+
+def test_molgraph_invalid_smiles_raises_valueerror():
+    """MolGraph should raise ValueError on invalid SMILES."""
+    args = Namespace(use_cuikmolmaker_featurization=False, bond_drop_rate=0.0)
+    with pytest.raises(ValueError, match="Invalid SMILES"):
+        MolGraph("not_a_valid_smiles", args=args)

--- a/tests/unit/test_model_utils.py
+++ b/tests/unit/test_model_utils.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# MIT License
+
+# Copyright (c) 2021 Tencent AI Lab.  All rights reserved.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Tests for model building, optimizer construction, and checkpoint utilities.
+Requires cuik_molmaker (skip if not installed).
+"""
+import os
+import tempfile
+from argparse import Namespace
+
+import pytest
+import torch
+from torch import nn
+
+cuik_molmaker = pytest.importorskip("cuik_molmaker")
+
+from kermt.util.utils import (
+    build_model, build_optimizer, get_ffn_layer_names, save_model_for_restart,
+)
+from kermt.util.nn_utils import param_count_trainable, param_count_total
+
+
+def _minimal_finetune_args(**overrides):
+    """Builds a minimal Namespace for constructing a KermtFinetuneTask."""
+    defaults = dict(
+        parser_name='finetune', hidden_size=64, depth=2,
+        num_attn_head=2, num_mt_block=1, bias=False, dense=False,
+        undirected=False, output_size=1, cuda=False, dropout=0.0,
+        activation='ReLU', ffn_hidden_size=None, ffn_num_layers=2,
+        self_attention=False, attn_hidden=4, attn_out=4,
+        features_only=False, features_size=0, features_dim=0,
+        use_input_features=False, embedding_output_type='atom',
+        dataset_type='regression', dist_coff=0.1, bond_drop_rate=0.0,
+        num_tasks=1, fine_tune_coff=1.0,
+        init_lr=1e-4, weight_decay=0.0,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# build_model / ffn_hidden_size default
+# ---------------------------------------------------------------------------
+
+def test_ffn_hidden_size_defaults_to_hidden_size():
+    """When ffn_hidden_size is None, FFN layers should use hidden_size."""
+    args = _minimal_finetune_args(ffn_hidden_size=None, ffn_num_layers=3, num_tasks=3)
+    model = build_model(args)
+    ffn = model.mol_atom_from_atom_ffn
+    linear_layers = [m for m in ffn if isinstance(m, nn.Linear)]
+    assert linear_layers[0].out_features == 64, \
+        f"Expected hidden_size=64, got {linear_layers[0].out_features}"
+
+
+def test_ffn_hidden_size_explicit():
+    """When ffn_hidden_size is set, FFN layers should use that value."""
+    args = _minimal_finetune_args(ffn_hidden_size=128, ffn_num_layers=3, num_tasks=3)
+    model = build_model(args)
+    ffn = model.mol_atom_from_atom_ffn
+    linear_layers = [m for m in ffn if isinstance(m, nn.Linear)]
+    assert linear_layers[0].out_features == 128, \
+        f"Expected 128, got {linear_layers[0].out_features}"
+
+
+def test_build_model_initializes_all_params():
+    """build_model should call initialize_weights on all parameters."""
+    args = _minimal_finetune_args()
+    model = build_model(args)
+    # Biases should be zeroed by initialize_weights
+    for name, param in model.state_dict().items():
+        if 'bias' in name and param.dim() == 1:
+            assert torch.all(param == 0), f"Bias {name} should be zero-initialized"
+
+
+# ---------------------------------------------------------------------------
+# get_ffn_layer_names
+# ---------------------------------------------------------------------------
+
+def test_ffn_layer_names_excludes_encoder():
+    args = _minimal_finetune_args()
+    model = build_model(args)
+    ffn_names = get_ffn_layer_names(model)
+    for name in ffn_names:
+        assert "kermt" not in name, f"FFN name {name} should not contain 'kermt'"
+    assert len(ffn_names) > 0
+
+
+def test_ffn_and_encoder_cover_all_params():
+    args = _minimal_finetune_args()
+    model = build_model(args)
+    ffn_names = set(get_ffn_layer_names(model))
+    all_names = set(n for n, _ in model.named_parameters())
+    encoder_names = all_names - ffn_names
+    assert len(encoder_names) > 0, "Should have encoder params"
+    assert ffn_names | encoder_names == all_names
+
+
+# ---------------------------------------------------------------------------
+# build_optimizer
+# ---------------------------------------------------------------------------
+
+def test_optimizer_has_two_param_groups():
+    args = _minimal_finetune_args(fine_tune_coff=0.5)
+    model = build_model(args)
+    optimizer = build_optimizer(model, args)
+    assert len(optimizer.param_groups) == 2
+    assert optimizer.param_groups[0]['lr'] == args.init_lr * 0.5
+    assert optimizer.param_groups[1]['lr'] == args.init_lr
+
+
+def test_encoder_frozen_when_fine_tune_coff_zero():
+    args = _minimal_finetune_args(fine_tune_coff=0.0)
+    model = build_model(args)
+    build_optimizer(model, args)
+    ffn_names = set(get_ffn_layer_names(model))
+    for name, param in model.named_parameters():
+        if name not in ffn_names:
+            assert not param.requires_grad, f"Encoder param {name} should be frozen"
+    # FFN linear layers (mol_atom_from_atom_ffn, mol_atom_from_bond_ffn) should be trainable.
+    # readout.cached_zero_vector is a constant placeholder (requires_grad=False by design).
+    for name, param in model.named_parameters():
+        if name in ffn_names:
+            if "mol_atom_from_atom_ffn" in name or "mol_atom_from_bond_ffn" in name:
+                assert param.requires_grad, f"FFN param {name} should be trainable"
+            elif name == "readout.cached_zero_vector":
+                assert not param.requires_grad, f"{name} is a constant, should not be trainable"
+
+
+def test_encoder_frozen_near_zero_coff():
+    """fine_tune_coff close to zero (within tolerance) should also freeze encoder."""
+    args = _minimal_finetune_args(fine_tune_coff=1e-7)
+    model = build_model(args)
+    build_optimizer(model, args)
+    ffn_names = set(get_ffn_layer_names(model))
+    for name, param in model.named_parameters():
+        if name not in ffn_names:
+            assert not param.requires_grad, f"Encoder param {name} should be frozen"
+
+
+def test_frozen_encoder_param_counts():
+    """With frozen encoder, trainable count should be less than total."""
+    args = _minimal_finetune_args(fine_tune_coff=0.0)
+    model = build_model(args)
+    build_optimizer(model, args)
+    assert param_count_trainable(model) < param_count_total(model)
+
+
+# ---------------------------------------------------------------------------
+# save_model_for_restart
+# ---------------------------------------------------------------------------
+
+def test_save_model_for_restart_contents():
+    """Checkpoint should contain model, optimizer, scheduler state and epoch."""
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+    args = Namespace(checkpoint_path="/some/pretrain.pt", other_arg="value")
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        save_model_for_restart(path, model, optimizer, scheduler,
+                               scaler=None, features_scaler=None,
+                               args=args, epoch=5)
+        state = torch.load(path, weights_only=False)
+        assert 'state_dict' in state
+        assert 'optimizer' in state
+        assert 'scheduler' in state
+        assert state['epoch'] == 5
+        assert state['data_scaler'] is None
+        assert state['features_scaler'] is None
+        assert not hasattr(state['args'], 'checkpoint_path'), \
+            "checkpoint_path should be stripped from saved args"
+        assert state['args'].other_arg == "value"
+    finally:
+        os.unlink(path)
+
+
+def test_save_model_for_restart_loadable():
+    """Saved checkpoint should be loadable and contain correct model weights."""
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+    args = Namespace(other_arg="value")
+
+    expected_weight = model.weight.clone()
+
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+        path = f.name
+    try:
+        save_model_for_restart(path, model, optimizer, scheduler,
+                               scaler=None, features_scaler=None,
+                               args=args, epoch=3)
+        state = torch.load(path, weights_only=False)
+        loaded_model = nn.Linear(4, 2)
+        loaded_model.load_state_dict(state['state_dict'])
+        assert torch.equal(loaded_model.weight, expected_weight)
+    finally:
+        os.unlink(path)

--- a/tests/unit/test_nn_utils.py
+++ b/tests/unit/test_nn_utils.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# MIT License
+
+# Copyright (c) 2021 Tencent AI Lab.  All rights reserved.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+import torch
+from torch import nn
+
+from kermt.util.nn_utils import param_count_trainable, param_count_total, initialize_weights
+
+
+# ---------------------------------------------------------------------------
+# param_count_trainable / param_count_total
+# ---------------------------------------------------------------------------
+
+def test_param_count_all_trainable():
+    model = nn.Linear(10, 5)  # 10*5 + 5 = 55 params
+    assert param_count_trainable(model) == 55
+    assert param_count_total(model) == 55
+
+
+def test_param_count_frozen_weight():
+    model = nn.Linear(10, 5)
+    model.weight.requires_grad = False
+    assert param_count_trainable(model) == 5  # only bias
+    assert param_count_total(model) == 55
+
+
+def test_param_count_trainable_leq_total():
+    model = nn.Sequential(nn.Linear(10, 5), nn.Linear(5, 2))
+    model[0].weight.requires_grad = False
+    assert param_count_trainable(model) <= param_count_total(model)
+
+
+# ---------------------------------------------------------------------------
+# initialize_weights with init_param_names
+# ---------------------------------------------------------------------------
+
+def test_initialize_weights_no_param_names_is_noop():
+    """When init_param_names is None (default), no parameters should be modified."""
+    model = nn.Linear(4, 2)
+    original = {k: v.clone() for k, v in model.state_dict().items()}
+    initialize_weights(model, init_param_names=None)
+    for k, v in model.state_dict().items():
+        assert torch.equal(v, original[k]), f"Parameter {k} should not change"
+
+
+def test_initialize_weights_selective():
+    """Only parameters whose names are in init_param_names should be modified.
+    initialize_weights zeros biases (dim=1) and applies xavier_normal_ to weights (dim>=2).
+    Unselected parameters should remain at their PyTorch default init (kaiming_uniform_)."""
+    model = nn.Sequential(nn.Linear(4, 3), nn.Linear(3, 2))
+    original = {k: v.clone() for k, v in model.state_dict().items()}
+
+    # Only init the second layer
+    init_names = [n for n in model.state_dict().keys() if n.startswith("1.")]
+    initialize_weights(model, init_param_names=init_names)
+
+    for k, v in model.state_dict().items():
+        if k in init_names:
+            if v.dim() == 1:
+                assert torch.all(v == 0), f"Bias {k} should be zeroed by initialize_weights"
+            else:
+                # Weight was re-initialized with xavier_normal_, should differ from default kaiming_uniform_
+                assert not torch.equal(v, original[k]), f"Weight {k} should be re-initialized"
+        else:
+            assert torch.equal(v, original[k]), f"Parameter {k} should not change"
+
+
+def test_initialize_weights_all_params():
+    """When all param names are given, biases should be zeroed and weights re-initialized."""
+    model = nn.Linear(4, 3, bias=True)
+    original_weight = model.state_dict()["weight"].clone()
+    all_names = list(model.state_dict().keys())
+    initialize_weights(model, init_param_names=all_names)
+    assert torch.all(model.state_dict()["bias"] == 0), "Bias should be zeroed"
+    assert not torch.equal(model.state_dict()["weight"], original_weight), \
+        "Weight should be re-initialized with xavier_normal_"
+
+
+def test_initialize_weights_distinct_init():
+    """Different model_idx values should produce different initializations."""
+    torch.manual_seed(0)
+    m1 = nn.Linear(8, 4, bias=False)
+    names = list(m1.state_dict().keys())
+    initialize_weights(m1, distinct_init=True, model_idx=0, init_param_names=names)
+    w1 = m1.weight.clone()
+
+    torch.manual_seed(0)
+    m2 = nn.Linear(8, 4, bias=False)
+    initialize_weights(m2, distinct_init=True, model_idx=1, init_param_names=names)
+    w2 = m2.weight.clone()
+
+    assert not torch.equal(w1, w2), "Different model_idx should produce different init"

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# MIT License
+
+# Copyright (c) 2021 Tencent AI Lab.  All rights reserved.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from kermt.util.scheduler import NoamLR
+
+
+def _make_scheduler(num_groups=2, fine_tune_coff=0.5):
+    """Helper to create a NoamLR scheduler with the given number of param groups."""
+    model = nn.Linear(4, 2)
+    param_groups = [{'params': model.parameters(), 'lr': 1e-4}]
+    for _ in range(num_groups - 1):
+        param_groups.append({'params': [], 'lr': 1e-4})
+    optimizer = torch.optim.Adam(param_groups)
+    return NoamLR(
+        optimizer=optimizer,
+        warmup_epochs=1, total_epochs=5, steps_per_epoch=10,
+        init_lr=1e-4, max_lr=1e-3, final_lr=1e-5,
+        fine_tune_coff=fine_tune_coff, fine_tune_param_idx=0,
+    )
+
+
+def test_lr_coff_dtype_is_float():
+    """lr_coff must be float so multiplication with float lr values works correctly."""
+    scheduler = _make_scheduler()
+    assert scheduler.lr_coff.dtype == np.float64, \
+        f"lr_coff dtype should be float64, got {scheduler.lr_coff.dtype}"
+
+
+def test_lr_coff_values():
+    scheduler = _make_scheduler(fine_tune_coff=0.5)
+    assert scheduler.lr_coff[0] == 0.5
+    assert scheduler.lr_coff[1] == 1.0
+
+
+def test_lr_scaled_by_fine_tune_coff():
+    """After stepping, the fine-tuned param group lr should be scaled down."""
+    scheduler = _make_scheduler(fine_tune_coff=0.5)
+    scheduler.step()
+    lrs = scheduler.get_lr()
+    assert lrs[0] < lrs[1], "Fine-tuned group should have lower lr"
+    assert abs(lrs[0] / lrs[1] - 0.5) < 1e-6, "lr ratio should be 0.5"
+
+
+def test_lr_coff_single_param_group():
+    """Scheduler with a single param group and fine_tune_coff=1.0."""
+    scheduler = _make_scheduler(num_groups=1, fine_tune_coff=1.0)
+    scheduler.step()
+    lrs = scheduler.get_lr()
+    assert len(lrs) == 1
+    assert lrs[0] > 0


### PR DESCRIPTION
- Atomic checkpoint saves to prevent corruption on kill (kermttrainer)
- load_checkpoint returns (model, state) to enable optimizer/scheduler resume for interrupted finetune jobs
- Remove attn_out and fine_tune_coff from checkpoint-loaded model args to prevent model size blowup from old checkpoints (attn_out default 128→8)
- Add num_tasks to model args for blinded test data prediction
- Default ffn_hidden_size to hidden_size when not specified
- Support blinded test data: skip loss/metrics, save predictions only
- Initialize TensorBoard writer before training loop
- Reset random seeds per fold in cross_validate
- Prevent split_data from deleting vocab files in output directory
- Fix split_data file count ceiling division
- Auto-detect GPU topology and configure NCCL P2P for pretrain DDP
- Validate SMILES in MolGraph and skip invalid SMILES in vocab building
- Fix lr_coff float type and TorchVocab return type hint