### PR TITLE
docs(readme): reference the KERMT v2.0 released model (NV-KERMT-70M-v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,23 @@ conda env create -n kermt -f environment.yml
 conda activate kermt
 ```
 
-## Pretained Model Download
-The pretrained models models can be downloaded from the following links. 
+## Pretrained Model Download
+
+### KERMT v2.0 (recommended)
+
+The released KERMT v2.0 model is hosted on Hugging Face: [**nvidia/NV-KERMT-70M-v2**](https://huggingface.co/nvidia/NV-KERMT-70M-v2). The repository bundles the pretrained hybrid checkpoint (`kermt_contrastive_v2.0.pt`) together with its vocabulary files (`pretrain_atom_vocab.json`, `pretrain_bond_vocab.json`, `pretrain_smiles_vocab.pkl`), distributed under the NVIDIA Open Model License. The vocabulary files are an inseparable part of the model — keep them alongside the checkpoint.
+
+Download the full bundle into a local directory:
+```bash
+pip install huggingface_hub
+huggingface-cli download nvidia/NV-KERMT-70M-v2 --local-dir model/NV-KERMT-70M-v2
+```
+
+### GROVER base weights
+
+KERMT builds on the original GROVER encoder. The base GROVER weights can be downloaded from:
    - [GROVER<sub>base</sub>](https://1drv.ms/u/s!Ak4XFI0qaGjOhdlwa2_h-8WAymU1AQ)
-   - [GROVER<sub>large</sub>](https://1drv.ms/u/s!Ak4XFI0qaGjOhdlxC3mGn0LC1NFd6g) 
+   - [GROVER<sub>large</sub>](https://1drv.ms/u/s!Ak4XFI0qaGjOhdlxC3mGn0LC1NFd6g)
 
 
 ## Pretraining

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ conda activate kermt
 
 ### KERMT v2.0 (recommended)
 
-The released KERMT v2.0 model is hosted on Hugging Face: [**nvidia/NV-KERMT-70M-v2**](https://huggingface.co/nvidia/NV-KERMT-70M-v2). The repository bundles the pretrained hybrid checkpoint (`kermt_contrastive_v2.0.pt`) together with its vocabulary files (`pretrain_atom_vocab.json`, `pretrain_bond_vocab.json`, `pretrain_smiles_vocab.pkl`), distributed under the NVIDIA Open Model License. The vocabulary files are an inseparable part of the model — keep them alongside the checkpoint.
+The released KERMT v2.0 model is hosted on Hugging Face: [**nvidia/NV-KERMT-70M-v2**](https://huggingface.co/nvidia/NV-KERMT-70M-v2). Its contrastive pretraining is described in the Contrastive KERMT preprint ([arXiv:2606.11508](https://arxiv.org/abs/2606.11508)). The repository bundles the pretrained hybrid checkpoint (`kermt_contrastive_v2.0.pt`) together with its vocabulary files (`pretrain_atom_vocab.json`, `pretrain_bond_vocab.json`, `pretrain_smiles_vocab.pkl`), distributed under the NVIDIA Open Model License. The vocabulary files are an inseparable part of the model — keep them alongside the checkpoint.
 
 Download the full bundle into a local directory:
 ```bash
@@ -211,6 +211,7 @@ python main.py predict \
 - Paper:[Multitask finetuning and acceleration of chemical
 pretrained models for small molecule drug
 property prediction](https://arxiv.org/abs/2510.12719)
+- Contrastive KERMT (v2.0) preprint: [arXiv:2606.11508](https://arxiv.org/abs/2606.11508)
 - Dataset: [Figshare link](https://figshare.com/articles/dataset/Datasets_for_Multitask_finetuning_and_acceleration_of_chemical_pretrained_models_for_small_molecule_drug_property_prediction_/30350548/2)
 - [Original GROVER paper](https://arxiv.org/abs/2007.02835)
 - [Original GROVER implementation](https://github.com/tencent-ailab/grover)


### PR DESCRIPTION
The Pretrained Model Download section only linked the original GROVER weights. Add the released KERMT v2.0 hybrid model on Hugging Face (nvidia/NV-KERMT-70M-v2) — checkpoint kermt_contrastive_v2.0.pt plus its bundled vocab files, under the NVIDIA Open Model License — with a huggingface-cli download command, and keep the GROVER base weights as the underlying encoder. Also fix the heading typo (Pretained -> Pretrained) and a duplicated word.