### PR TITLE
Add co-located evals for the 8 agent skills

### DIFF
--- a/agent/skills/kermt-add-cmim-pretrain/evals/evals.json
+++ b/agent/skills/kermt-add-cmim-pretrain/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "kermt-add-cmim-pretrain",
+  "evals": [
+    {
+      "id": "kermt-add-cmim-pretrain-001",
+      "prompt": "I want to use kermt-add-cmim-pretrain to upgrade my grover_base encoder checkpoint at ./checkpoints/grover_base_ep50.pt and then continue pretraining on my SMILES corpus at ./data/zinc_subset.csv with 20 epochs and batch size 64.",
+      "expected_output": "The agent invoked the kermt-add-cmim-pretrain workflow, validating the grover_base checkpoint with check_checkpoint --mode upgrade_to_hybrid, validating the corpus with check_data --mode pretrain, running upgrade_to_hybrid.py to produce a hybrid checkpoint, then launching continue-pretraining with the specified hyperparameters (20 epochs, batch size 64).",
+      "assertions": [
+        "The agent read the kermt-add-cmim-pretrain SKILL.md to understand the workflow steps",
+        "The agent ran or described running check_checkpoint --mode upgrade_to_hybrid on the user's grover_base checkpoint",
+        "The agent ran or described running upgrade_to_hybrid.py to convert the checkpoint to hybrid format",
+        "The agent initiated or described initiating the continue-pretrain step with --epochs 20 and --batch-size 64 on the user's corpus",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-add-cmim-pretrain",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-add-cmim-pretrain-002",
+      "prompt": "I have a pretrained grover_base encoder checkpoint (encoder-only, no task heads) and I'd like to add a contrastive MIM decoder to it and then keep pretraining on my molecular dataset so I get a hybrid model with both vocab and contrast objectives. The checkpoint is at /models/grover_enc.pt and my data is /data/molecules.csv. How do I do this?",
+      "expected_output": "The agent identified this as the kermt-add-cmim-pretrain workflow, explained the checkpoint conversion step (adding randomly-initialized cMIM decoder + latent_dist), validated inputs, and guided the user through the full pipeline of upgrading the checkpoint and continuing hybrid pretraining on their corpus.",
+      "assertions": [
+        "The agent identified the need to convert the encoder-only checkpoint to a hybrid checkpoint before continuing pretraining",
+        "The agent referenced or consulted the kermt-add-cmim-pretrain skill documentation",
+        "The agent explained or executed the upgrade_to_hybrid.py step to add the cMIM decoder and latent_dist layers",
+        "The agent described or initiated the subsequent continue-pretrain phase with hybrid (vocab + contrast) objectives",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-add-cmim-pretrain",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-add-cmim-pretrain-003",
+      "prompt": "We trained a GROVER-base model on our proprietary chemical library for 100 epochs but only used the standard vocabulary prediction objective. Our team now wants to incorporate the contrastive SMILES-reconstruction loss to improve molecular representations without restarting from scratch. The checkpoint is saved at /shared/models/grover_base_100ep.pt and our training corpus is /shared/data/proprietary_smiles.csv (about 2M compounds). Can you set this up? We have 2 GPUs available (ids 0 and 1).",
+      "expected_output": "The agent recognized this as a real-world use case for kermt-add-cmim-pretrain, set up the full workflow including checkpoint validation, upgrade to hybrid format, data preparation, and launched multi-GPU continue-pretraining with the hybrid objective on the user's proprietary corpus.",
+      "assertions": [
+        "The agent identified this scenario as matching the kermt-add-cmim-pretrain skill (extending an existing grover_base with cMIM without restarting)",
+        "The agent validated or described validating the checkpoint to ensure it doesn't already have contrast heads or task FFN heads",
+        "The agent set up or described setting up the run with --gpus 0,1 for multi-GPU training",
+        "The agent created or described creating the run directory and executing the full pipeline from upgrade through continue-pretrain",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-add-cmim-pretrain",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-add-cmim-pretrain-004",
+      "prompt": "How do I finetune my hybrid kermt checkpoint on a downstream property prediction task like solubility? I have a labeled dataset with SMILES and logS values.",
+      "expected_output": "The agent recognized this as a downstream finetuning request on a property prediction task, not a checkpoint conversion or pretraining task, and directed the user to the appropriate finetuning skill rather than kermt-add-cmim-pretrain.",
+      "assertions": [
+        "The agent did not invoke the kermt-add-cmim-pretrain workflow since the user already has a hybrid checkpoint and wants to finetune, not pretrain",
+        "The agent identified this as a supervised finetuning task rather than a pretraining or checkpoint-upgrade task",
+        "The agent suggested an appropriate finetuning workflow or asked clarifying questions about the downstream task setup",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/agent/skills/kermt-continue-pretrain/evals/evals.json
+++ b/agent/skills/kermt-continue-pretrain/evals/evals.json
@@ -1,0 +1,74 @@
+{
+  "skill_name": "kermt-continue-pretrain",
+  "evals": [
+    {
+      "id": "kermt-continue-pretrain-001",
+      "prompt": "I want to use kermt-continue-pretrain with my checkpoint at /data/checkpoints/cmim_epoch50.pt and my pretrain CSV at /data/corpus/molecules.csv. Use 2 GPUs (0 and 1), batch size 128, and run for 20 epochs.",
+      "expected_output": "The agent invoked the kermt-continue-pretrain skill, validated the cmim checkpoint and CSV inputs, prepared the data into shard/vocab/features form, auto-detected --pretrain_mode as cmim based on the checkpoint type, and launched pretrain_ddp.py in the kermt container (detached) with --gpus 0,1 --batch-size 128 --epochs 20.",
+      "assertions": [
+        "The agent read the kermt-continue-pretrain SKILL.md to understand the workflow requirements",
+        "The agent validated the checkpoint path /data/checkpoints/cmim_epoch50.pt and CSV path /data/corpus/molecules.csv exist and are of the correct format",
+        "The agent determined the pretrain_mode as cmim based on the checkpoint type and configured the launch command accordingly",
+        "The agent launched pretrain_ddp.py inside the kermt container in detached mode with the specified GPU, batch size, and epoch parameters",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-continue-pretrain",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-continue-pretrain-002",
+      "prompt": "I have a grover_base checkpoint from a previous KERMT run and a new SMILES dataset. I want to continue pretraining on this new corpus. The checkpoint is at ./runs/grover_base_v2/best.pt and the dataset is at ./data/new_smiles.csv. I'm on a single T4 GPU so I'll need a smaller batch size. Can you set this up?",
+      "expected_output": "The agent recognized this as a continue-pretrain workflow, validated the grover_base checkpoint and SMILES CSV, auto-dispatched --pretrain_mode as grover_base vocab-only, adjusted batch size to 32-64 appropriate for a T4 GPU, prepared the data, and launched pretrain_ddp.py in detached mode inside the kermt container.",
+      "assertions": [
+        "The agent identified this as a kermt-continue-pretrain task and consulted the SKILL.md for hardware guidance",
+        "The agent recommended a batch size of 32-64 based on the T4 GPU's 16 GB VRAM as documented in the hardware requirements table",
+        "The agent validated the grover_base checkpoint and set --pretrain_mode to grover_base vocab-only",
+        "The agent prepared the data and launched pretrain_ddp.py in the kermt container with appropriate single-GPU settings",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-continue-pretrain",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-continue-pretrain-003",
+      "prompt": "We ran a hybrid KERMT pretrain job last week but it only got through 30 epochs before the instance was preempted. I have the checkpoint saved at /shared/kermt_runs/hybrid_ep30/checkpoint_ep30.pt and the same training CSV at /shared/data/pretrain_corpus.csv. I also have a separate validation set at /shared/data/val_molecules.csv. Can you resume training for another 50 epochs with a lower learning rate (max-lr 1e-4) and save checkpoints every 200 steps? We have 4x A100 80GB GPUs available.",
+      "expected_output": "The agent set up a continue-pretrain run from the hybrid checkpoint with --val-csv pointing to the separate validation set, --epochs 50, --max-lr 1e-4, --save-interval 200, using all 4 A100 GPUs with default batch size 256, auto-dispatching --pretrain_mode as hybrid, and launched pretrain_ddp.py detached in the kermt container.",
+      "assertions": [
+        "The agent validated the hybrid checkpoint and both CSV paths, and auto-dispatched --pretrain_mode as hybrid",
+        "The agent configured the run with --val-csv /shared/data/val_molecules.csv, --epochs 50, --max-lr 1e-4, and --save-interval 200",
+        "The agent used the default batch size 256 appropriate for A100 80GB GPUs and configured all 4 GPUs",
+        "The agent launched pretrain_ddp.py inside the kermt container in detached mode and reported the run directory",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-continue-pretrain",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-continue-pretrain-004",
+      "prompt": "How do I fine-tune a KERMT model on a downstream property prediction task? I have a checkpoint and a labeled CSV with SMILES and pIC50 values.",
+      "expected_output": "The agent recognized this is a fine-tuning/property-prediction task rather than a continue-pretrain task, and did not invoke kermt-continue-pretrain. It either directed the user to the appropriate fine-tuning skill or explained that continue-pretrain is for unsupervised pretraining on unlabeled SMILES, not supervised property prediction.",
+      "assertions": [
+        "The agent did NOT invoke kermt-continue-pretrain since the user's task is supervised fine-tuning, not unsupervised continue-pretraining",
+        "The agent explained the distinction between continue-pretraining (unlabeled SMILES corpus) and fine-tuning (labeled property prediction)",
+        "The agent suggested the appropriate fine-tuning workflow or skill for downstream property prediction tasks",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    },
+    {
+      "id": "kermt-continue-pretrain-005",
+      "prompt": "I'd like to continue pretraining from the publicly released KERMT model nvidia/NV-KERMT-70M-v2 on my own SMILES corpus at /data/corpus.csv for a few more epochs. I don't have the checkpoint locally yet.",
+      "expected_output": "The agent recognized that no --ckpt was provided, obtained explicit consent (or honored --pretrained-release) to download the released hybrid model nvidia/NV-KERMT-70M-v2 via fetch_released_model.py, noted the bundle ships its three pretrain vocab files alongside the checkpoint so the authoritative-vocab pass-through works automatically, validated the checkpoint for continue-pretrain (auto-detecting hybrid mode), prepared the corpus, and launched pretrain_ddp.py detached in the kermt container.",
+      "assertions": [
+        "The agent read the kermt-continue-pretrain SKILL.md and, finding no --ckpt, defaulted to the released model nvidia/NV-KERMT-70M-v2 via the consent gate (or an explicit --pretrained-release flag)",
+        "The agent downloaded the released bundle with fetch_released_model.py (huggingface_hub) into the --model-dir mount, relying on the bundled pretrain_*_vocab files being auto-detected in the checkpoint's parent directory",
+        "The agent validated the downloaded checkpoint using check_checkpoint.py with --mode continue_pretrain and auto-dispatched --pretrain_mode as hybrid based on the checkpoint type",
+        "The agent prepared the corpus and launched pretrain_ddp.py inside the kermt container in detached mode, reporting the run directory",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-continue-pretrain",
+      "expected_script": null
+    }
+  ]
+}

--- a/agent/skills/kermt-embed/evals/evals.json
+++ b/agent/skills/kermt-embed/evals/evals.json
@@ -1,0 +1,74 @@
+{
+  "skill_name": "kermt-embed",
+  "evals": [
+    {
+      "id": "kermt-embed-001",
+      "prompt": "I need to use kermt-embed to extract embeddings from my grover_base checkpoint at /home/user/checkpoints/grover_base.pt using the SMILES file at /home/user/data/molecules.csv. Can you run this with batch size 128?",
+      "expected_output": "The agent executed the kermt-embed workflow to extract per-molecule embeddings from the grover_base checkpoint, producing atom_from_atom.npy, bond_from_atom.npy, atom_from_bond.npy, bond_from_bond.npy, canonical_smiles metadata, and validity metadata in the run output directory, using batch size 128.",
+      "assertions": [
+        "The agent read the kermt-embed SKILL.md to understand the workflow steps",
+        "The agent ran the system check via kermt_container.sh check_system",
+        "The agent validated the checkpoint using check_checkpoint.py with --mode embed",
+        "The agent launched run_extract_embeddings.py with --batch-size 128 and reported the output directory containing the .npy files",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-embed",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-embed-002",
+      "prompt": "I have a CSV of 5000 SMILES strings and a pretrained KERMT hybrid encoder checkpoint. I want to get fixed-size vector representations for each molecule so I can cluster them downstream. How do I get those embeddings out?",
+      "expected_output": "The agent identified this as an embedding extraction task and walked through or executed the kermt-embed workflow, explaining that task/extract_embeddings.py featurizes SMILES on the fly and produces per-readout .npy embedding files suitable for downstream clustering.",
+      "assertions": [
+        "The agent identified the need for the kermt-embed skill based on the user's description of extracting vector representations from a KERMT encoder checkpoint",
+        "The agent explained or executed the checkpoint validation step to confirm the hybrid checkpoint has an encoder",
+        "The agent described or ran the data preparation and embedding extraction steps, noting that no pre-computed features are needed",
+        "The agent informed the user about the four output .npy files (atom_from_atom, bond_from_atom, atom_from_bond, bond_from_bond) and their shapes",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-embed",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-embed-003",
+      "prompt": "We're building a molecular similarity search engine. Our team fine-tuned a KERMT model on toxicity prediction and now we want to embed our entire compound library (about 50k molecules in library.csv) using that finetuned checkpoint at /models/tox_finetuned.ckpt. We'll index the embeddings in FAISS afterward. Can you extract the embeddings for us?",
+      "expected_output": "The agent executed the full kermt-embed workflow against the finetuned toxicity checkpoint and the 50k-molecule library CSV, producing the four readout .npy files plus metadata in a timestamped run directory, ready for the user to load into FAISS.",
+      "assertions": [
+        "The agent recognized this as a kermt-embed use case and consulted the SKILL.md for the correct workflow",
+        "The agent validated both the finetuned checkpoint (confirming it has an encoder) and the library.csv data file",
+        "The agent executed the embedding extraction runner with appropriate parameters for the 50k molecule dataset",
+        "The agent reported the output location including the four .npy embedding files and metadata, noting they are ready for FAISS indexing",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-embed",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-embed-004",
+      "prompt": "I want to fine-tune my KERMT model on a regression task predicting LogP values. I have a training CSV with SMILES and logP columns and a grover_base checkpoint. How do I set up and run the training?",
+      "expected_output": "The agent recognized this as a fine-tuning/training request rather than an embedding extraction task and did not invoke the kermt-embed skill, instead directing the user toward the appropriate fine-tuning workflow or skill.",
+      "assertions": [
+        "The agent did not invoke the kermt-embed workflow since the user wants to fine-tune, not extract embeddings",
+        "The agent clarified the distinction between embedding extraction and model fine-tuning",
+        "The agent suggested looking for a fine-tuning skill or workflow appropriate for regression tasks on molecular properties",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    },
+    {
+      "id": "kermt-embed-005",
+      "prompt": "I don't have my own KERMT checkpoint. Can you extract per-molecule embeddings for the SMILES in /data/biogen_admet.csv using the publicly released model? I want all four readout types so I can cluster the compounds downstream.",
+      "expected_output": "The agent recognized that no --ckpt was provided and defaulted to the released hybrid model nvidia/NV-KERMT-70M-v2, obtained explicit consent (or honored --pretrained-release) before downloading, fetched the bundle with fetch_released_model.py via huggingface_hub into the --model-dir mount, validated the downloaded checkpoint for an encoder, and ran run_extract_embeddings.py to produce the four readout .npy files.",
+      "assertions": [
+        "The agent read the kermt-embed SKILL.md and, finding no --ckpt, defaulted to the released model nvidia/NV-KERMT-70M-v2 rather than erroring",
+        "The agent obtained explicit user consent (or honored an explicit --pretrained-release flag) before downloading, per the skill's released-model consent gate",
+        "The agent invoked fetch_released_model.py inside the kermt container to download the nvidia/NV-KERMT-70M-v2 bundle via huggingface_hub into the --model-dir mount, reusing an already-complete bundle if present",
+        "The agent validated the downloaded checkpoint using check_checkpoint.py with --mode embed and launched run_extract_embeddings.py, reporting the four readout .npy files (atom_from_atom, bond_from_atom, atom_from_bond, bond_from_bond)",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-embed",
+      "expected_script": null
+    }
+  ]
+}

--- a/agent/skills/kermt-finetune/evals/evals.json
+++ b/agent/skills/kermt-finetune/evals/evals.json
@@ -1,0 +1,74 @@
+{
+  "skill_name": "kermt-finetune",
+  "evals": [
+    {
+      "id": "kermt-finetune-001",
+      "prompt": "I want to use kermt-finetune with my pretrained cmim checkpoint at /models/cmim_pretrain.pt on my labeled dataset /data/solubility.csv. Use scaffold_balanced split, classification dataset type, and set epochs to 50 with batch size 16.",
+      "expected_output": "The agent invoked the kermt-finetune skill to validate the cmim checkpoint, validate the labeled CSV, prepare the data with scaffold_balanced splitting, and launched the finetune container detached with the specified hyperparameters (classification, 50 epochs, batch size 16).",
+      "assertions": [
+        "The agent read the kermt-finetune SKILL.md to understand the skill's requirements and parameters",
+        "The agent validated that the checkpoint /models/cmim_pretrain.pt is a valid pretrain checkpoint (cmim type)",
+        "The agent validated the labeled CSV and confirmed target columns before proceeding",
+        "The agent launched the finetune process with --dataset-type classification --epochs 50 --batch-size 16 --split-type scaffold_balanced and reported the run directory and container name",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-finetune",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-finetune-002",
+      "prompt": "I have a pretrained molecular encoder checkpoint (grover_base) and a CSV with SMILES and three regression targets (logP, solubility, melting_point). I need to train the model on this labeled data using the pretrained weights. Can you set it up with a learning rate of 0.0001 and 100 epochs?",
+      "expected_output": "The agent recognized this as a finetuning task for a pretrained KERMT encoder, validated the grover_base checkpoint and multi-target CSV, prepared the data, and launched the detached finetune run with the specified learning rate and epoch count.",
+      "assertions": [
+        "The agent identified this as a kermt-finetune workflow based on the description of finetuning a pretrained molecular encoder on labeled data",
+        "The agent validated the grover_base checkpoint and the CSV structure including the three target columns (logP, solubility, melting_point)",
+        "The agent configured the finetune with --targets logP solubility melting_point --init-lr 0.0001 --epochs 100 and dataset-type regression",
+        "The agent launched the finetune in a detached container and reported the run directory and container name",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-finetune",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-finetune-003",
+      "prompt": "We just finished pretraining our KERMT model with the hybrid objective and the checkpoint is saved at /workspace/kermt_runs/hybrid_pretrain/model.pt. Our medicinal chemistry team prepared a curated dataset of 5000 compounds with binary activity labels against JAK2 at /projects/jak2/jak2_activity.csv. They also prepared canonical train/val/test splits at /projects/jak2/splits/train.csv, /projects/jak2/splits/val.csv, and /projects/jak2/splits/test.csv. We need to finetune for classification using AUC as the metric with early stopping at epoch 20. Please set this up.",
+      "expected_output": "The agent set up a kermt-finetune run using the hybrid pretrain checkpoint, the JAK2 classification dataset with pre-determined splits, AUC metric, and early stopping at epoch 20, launching the training in a detached container.",
+      "assertions": [
+        "The agent read the kermt-finetune SKILL.md and identified that pre-split CSVs require --split-type index_predetermined with --val-csv and --test-csv flags",
+        "The agent validated the hybrid pretrain checkpoint and the labeled CSV with binary activity labels",
+        "The agent configured the run with --dataset-type classification --metric auc --early-stop-epoch 20 --split-type index_predetermined --val-csv /projects/jak2/splits/val.csv --test-csv /projects/jak2/splits/test.csv",
+        "The agent launched the detached finetune container and reported the run directory and container name to the user",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-finetune",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-finetune-004",
+      "prompt": "How do I convert a SMILES string to a molecular fingerprint using RDKit? I want to compute Tanimoto similarity between two molecules.",
+      "expected_output": "The agent provided guidance on using RDKit to generate molecular fingerprints and compute Tanimoto similarity, without invoking the kermt-finetune skill since this is a basic cheminformatics question unrelated to model finetuning.",
+      "assertions": [
+        "The agent recognized this as a general RDKit/cheminformatics question unrelated to KERMT model finetuning",
+        "The agent provided code or instructions for generating fingerprints and computing Tanimoto similarity using RDKit",
+        "The agent did not attempt to invoke the kermt-finetune skill or validate any checkpoints or CSVs",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    },
+    {
+      "id": "kermt-finetune-005",
+      "prompt": "I want to finetune the publicly released KERMT model (nvidia/NV-KERMT-70M-v2) on the Biogen multi-task ADME dataset at /data/biogen/train.csv — it has four regression endpoints: HLM, RLM, MDCK, and logS. I don't have a local checkpoint. Please set it up for 3 epochs to start.",
+      "expected_output": "The agent recognized that no --ckpt was provided, obtained explicit consent (or honored --pretrained-release) to download the released hybrid model nvidia/NV-KERMT-70M-v2 via fetch_released_model.py, validated the downloaded pretrain checkpoint for finetune init, validated the Biogen multi-task CSV, and launched a detached finetune run over the four HLM/RLM/MDCK/logS regression targets for 3 epochs.",
+      "assertions": [
+        "The agent read the kermt-finetune SKILL.md and, finding no --ckpt, defaulted to the released model nvidia/NV-KERMT-70M-v2 via the consent gate (or an explicit --pretrained-release flag)",
+        "The agent downloaded the released bundle with fetch_released_model.py (huggingface_hub) into the --model-dir mount before finetuning, reusing an already-complete bundle if present",
+        "The agent validated the downloaded checkpoint using check_checkpoint.py with --mode finetune_init and confirmed the four regression targets (HLM, RLM, MDCK, logS) in the CSV",
+        "The agent launched the detached finetune run with --dataset-type regression and --epochs 3, reporting the run directory and container name",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-finetune",
+      "expected_script": null
+    }
+  ]
+}

--- a/agent/skills/kermt-infer/evals/evals.json
+++ b/agent/skills/kermt-infer/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "kermt-infer",
+  "evals": [
+    {
+      "id": "kermt-infer-001",
+      "prompt": "I want to use kermt-infer to run predictions on my SMILES CSV at /data/molecules.csv using my finetuned checkpoint at /models/kermt_finetuned.ckpt. Can you run that for me?",
+      "expected_output": "The agent invoked the kermt-infer workflow: validated the finetuned checkpoint for task FFN heads, validated the SMILES CSV, prepared the data with rdkit_2d features, launched the blocking prediction run inside the kermt container, and reported the output predictions CSV path along with row count and target summary.",
+      "assertions": [
+        "The agent ran the system check via kermt_container.sh check_system before proceeding",
+        "The agent validated the checkpoint using check_checkpoint.py with --mode inference and confirmed has_task_ffn is true",
+        "The agent executed prepare_data.py to generate cleaned CSV and rdkit_2d_normalized features",
+        "The agent launched run_inference.py inside the kermt container and reported the predictions CSV location and summary",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-infer",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-infer-002",
+      "prompt": "I have a finetuned KERMT model checkpoint and a CSV file with about 500 SMILES strings. I need to generate property predictions for all of them. The checkpoint is at ./checkpoints/tox21_best.ckpt and the CSV is ./input/smiles_list.csv. How do I get predictions out?",
+      "expected_output": "The agent recognized this as a KERMT inference task, walked through the full inference workflow including checkpoint validation (ensuring task FFN heads exist), CSV validation, data preparation with feature generation, and launched the prediction run, ultimately producing a predictions.csv with per-target columns for the 500 molecules.",
+      "assertions": [
+        "The agent referenced or read the kermt-infer skill documentation to determine the correct workflow steps",
+        "The agent validated the checkpoint to confirm it is a finetuned model with task FFN heads rather than a pretrain checkpoint",
+        "The agent prepared the data by running prepare_data.py to clean the CSV and compute rdkit_2d_normalized features",
+        "The agent executed the blocking inference run and reported the output path and molecule/target counts",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-infer",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-infer-003",
+      "prompt": "We just finished finetuning our KERMT model on the BBBP dataset and the best checkpoint is saved at /workspace/kermt/runs/finetune_2024-11-15/best.ckpt. Our medicinal chemistry team sent over a file called candidates_round3.csv with 1200 candidate molecules (just SMILES, one per row). Can you score all of them with the model so we can prioritize synthesis? Use batch size 64 if possible.",
+      "expected_output": "The agent executed the kermt-infer workflow end-to-end with the specified checkpoint and candidate CSV, using batch size 64, producing a predictions.csv that the medicinal chemistry team can use to rank candidates for synthesis prioritization.",
+      "assertions": [
+        "The agent performed pre-flight system checks to ensure GPU availability and container readiness",
+        "The agent validated the checkpoint at the specified path and confirmed it contains task FFN heads suitable for inference",
+        "The agent validated candidates_round3.csv as a proper SMILES-only CSV and ran data preparation including rdkit_2d feature computation",
+        "The agent launched run_inference.py with --batch-size 64 and reported the final predictions CSV path with 1200 molecules scored",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-infer",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-infer-004",
+      "prompt": "I have a pretrained KERMT checkpoint and I want to compute molecular embeddings from the transformer encoder for a set of SMILES. Can you extract the hidden representations from the last layer without running any classification head?",
+      "expected_output": "The agent recognized that extracting hidden layer embeddings from a pretrained checkpoint (without task FFN heads) is not the same as running predictions with kermt-infer. The agent did not invoke kermt-infer and instead explained that this task requires a different approach, possibly suggesting custom scripting to extract encoder representations or redirecting to an appropriate tool.",
+      "assertions": [
+        "The agent did not attempt to run the kermt-infer workflow since the request is about embedding extraction, not task prediction",
+        "The agent clarified that kermt-infer requires a finetuned checkpoint with task FFN heads and would reject a pretrain checkpoint",
+        "The agent suggested an alternative approach for extracting encoder hidden representations rather than invoking the inference skill",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/agent/skills/kermt-monitor/evals/evals.json
+++ b/agent/skills/kermt-monitor/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "kermt-monitor",
+  "evals": [
+    {
+      "id": "kermt-monitor-001",
+      "prompt": "Can you run kermt-monitor on my run directory at runs/continue-pretrain_2026-05-17T10-23Z? I want to see the last 100 lines and get a JSON status report.",
+      "expected_output": "The agent used kermt-monitor to check the detached KERMT run in the specified directory, queried docker for container state, tailed the last 100 lines of the pretrain log, parsed progress lines, and returned a structured JSON status report including epoch, step, and val loss.",
+      "assertions": [
+        "The agent read the kermt-monitor SKILL.md to understand the workflow and options",
+        "The agent attempted to read run.json from the specified run directory to parse the manifest",
+        "The agent queried docker for the container state using docker ps or docker inspect",
+        "The agent tailed the pretrain_ddp.log file with --lines 100 and parsed progress metrics",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-monitor",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-monitor-002",
+      "prompt": "I kicked off a finetune job about an hour ago in detached mode. How do I check if it's still running and what the current loss is? The run directory is runs/finetune_2026-06-01T14-00Z.",
+      "expected_output": "The agent identified this as a monitoring task for a detached KERMT finetune run, checked the container status via docker, located and tailed finetune.log, and reported the current training progress including loss values.",
+      "assertions": [
+        "The agent identified the need to monitor a detached KERMT run without the user naming the skill explicitly",
+        "The agent checked run.json in runs/finetune_2026-06-01T14-00Z to determine the workflow type",
+        "The agent queried docker to determine whether the finetune container is still running or has exited",
+        "The agent tailed finetune.log and surfaced a human-friendly summary of current epoch, step, and val loss",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-monitor",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-monitor-003",
+      "prompt": "I'm running three pretraining jobs overnight on different datasets. Before I go to bed I want a quick status check on all of them. The run dirs are runs/pretrain-scratch_2026-06-02T22-00Z, runs/continue-pretrain_2026-06-02T22-05Z, and runs/add-cmim-pretrain_2026-06-02T22-10Z. Just give me a brief summary of each — are they still going, and what's the latest val loss?",
+      "expected_output": "The agent monitored all three detached KERMT pretrain runs by reading each run.json, checking docker container states, tailing pretrain_ddp.log for each, and providing a concise summary of running status and latest val loss for each job.",
+      "assertions": [
+        "The agent applied the kermt-monitor workflow to each of the three specified run directories",
+        "The agent checked docker container state for each run to confirm whether they are still active",
+        "The agent tailed pretrain_ddp.log in each logs directory and parsed the latest progress lines",
+        "The agent presented a brief consolidated summary showing running status and val loss for all three jobs",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-monitor",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-monitor-004",
+      "prompt": "How do I convert my KERMT model checkpoint to ONNX format for deployment?",
+      "expected_output": "The agent recognized this is a model export/conversion question unrelated to monitoring a detached KERMT run, and provided guidance on ONNX conversion without invoking kermt-monitor.",
+      "assertions": [
+        "The agent did not invoke or reference the kermt-monitor skill",
+        "The agent addressed the ONNX conversion question directly with relevant information or suggestions",
+        "The agent did not attempt to read run.json or query docker container state for monitoring purposes",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/agent/skills/kermt-pretrain-scratch/evals/evals.json
+++ b/agent/skills/kermt-pretrain-scratch/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "kermt-pretrain-scratch",
+  "evals": [
+    {
+      "id": "kermt-pretrain-scratch-001",
+      "prompt": "I want to use kermt-pretrain-scratch to train a new model on my custom polymer dataset at /data/polymers.csv. I have two A100 80GB GPUs available. Please use the hybrid pretrain target mode.",
+      "expected_output": "The agent invoked the kermt-pretrain-scratch skill to pretrain a fresh KERMT model from scratch on /data/polymers.csv using hybrid mode, configured for 2 A100 80GB GPUs with default batch size 256, built a new vocabulary from the corpus, and launched pretrain_ddp.py in detached mode inside the kermt container.",
+      "assertions": [
+        "The agent read the kermt-pretrain-scratch SKILL.md to understand the workflow and parameters",
+        "The agent configured the pretrain run with --csv /data/polymers.csv and --pretrain-target-mode hybrid",
+        "The agent confirmed the hardware setup (2 A100 80GB GPUs) and used the default batch size of 256",
+        "The agent launched pretrain_ddp.py in detached mode inside the kermt container and informed the user about expected long wall time",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-pretrain-scratch",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-pretrain-scratch-002",
+      "prompt": "I have a custom SMILES dataset of about 5 million molecules for a niche agrochemical domain. I want to train a completely new KERMT model from random initialization — no pretrained checkpoint. The CSV is at ~/agrochem_corpus.csv. I'd like to use the contrastive/SMILES reconstruction objective. I'm on a single V100 16GB.",
+      "expected_output": "The agent set up a from-scratch KERMT pretraining run on ~/agrochem_corpus.csv using cmim mode, adjusted the batch size to 32-64 for the V100 16GB GPU, built a new SMILES vocabulary from the corpus, and launched pretrain_ddp.py detached in the kermt container with single-GPU fallback settings.",
+      "assertions": [
+        "The agent identified this as a from-scratch pretrain task and referenced the kermt-pretrain-scratch skill",
+        "The agent recommended a reduced batch size (32-64) appropriate for V100 16GB VRAM and set --pretrain-target-mode cmim",
+        "The agent explained that a new vocabulary would be built from the corpus since no existing checkpoint is used",
+        "The agent warned the user about the significantly longer wall time expected for pretraining from scratch on a single GPU",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-pretrain-scratch",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-pretrain-scratch-003",
+      "prompt": "We're starting a new research project on metalorganic frameworks and none of the released KERMT checkpoints cover our chemistry. I have a curated corpus of 2M MOF-linker SMILES in /shared/mof_linkers_train.csv and a held-out validation set at /shared/mof_linkers_val.csv. We have a DGX node with 4x H100s. Can you set up the full pretraining pipeline from scratch using both the vocab and contrastive objectives together?",
+      "expected_output": "The agent configured and launched a from-scratch KERMT pretraining run in hybrid mode on the MOF-linker corpus with a separate validation set, utilizing all 4 H100 GPUs at default batch size 256, building a fresh vocabulary, and running pretrain_ddp.py detached in the kermt container.",
+      "assertions": [
+        "The agent recognized this as a from-scratch pretrain scenario due to no applicable released checkpoint and selected kermt-pretrain-scratch",
+        "The agent configured --csv /shared/mof_linkers_train.csv, --val-csv /shared/mof_linkers_val.csv, and --pretrain-target-mode hybrid",
+        "The agent set up multi-GPU training across 4 H100s with default batch size 256 and launched pretrain_ddp.py in detached mode",
+        "The agent provided an estimate or warning about multi-day wall time for pretraining from scratch on a 2M molecule corpus",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-pretrain-scratch",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-pretrain-scratch-004",
+      "prompt": "I already have a pretrained KERMT checkpoint from the official release and I want to continue training it on my proprietary drug-like molecules dataset for another 20 epochs. The checkpoint is at /models/kermt_base.pt and my data is at /data/drugs.csv. Can you help me set this up?",
+      "expected_output": "The agent correctly identified this as a continue-pretrain task (kermt-continue-pretrain) rather than a from-scratch pretrain, since the user explicitly has an existing checkpoint they want to extend, and directed the user accordingly.",
+      "assertions": [
+        "The agent recognized that loading an existing checkpoint for further training is not a from-scratch scenario",
+        "The agent suggested using kermt-continue-pretrain instead of kermt-pretrain-scratch",
+        "The agent explained the distinction: kermt-pretrain-scratch uses random initialization while kermt-continue-pretrain loads an existing checkpoint",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/agent/skills/kermt-setup/evals/evals.json
+++ b/agent/skills/kermt-setup/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "skill_name": "kermt-setup",
+  "evals": [
+    {
+      "id": "kermt-setup-001",
+      "prompt": "Run /kermt-setup to bootstrap my environment. The repo is at /home/user/kermt.",
+      "expected_output": "The agent invoked the kermt-setup skill, verified docker and nvidia-container-toolkit on the host, built or confirmed the kermt:latest image exists, and ran a GPU smoke test inside the container, reporting success or actionable errors for each step.",
+      "assertions": [
+        "The agent executed or described running $KERMT_REPO/agent/scripts/kermt_container.sh check_docker to verify docker availability",
+        "The agent executed or described running $KERMT_REPO/agent/scripts/kermt_container.sh check_gpu to verify GPU passthrough",
+        "The agent executed or described running $KERMT_REPO/agent/scripts/kermt_container.sh ensure_image to build or verify the kermt:latest image",
+        "The agent reported the outcome of the GPU smoke test to the user",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-setup",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-setup-002",
+      "prompt": "I just got a fresh Ubuntu machine with an NVIDIA A100. I need to prepare it so I can run kermt training workflows later. Can you check that docker and GPU passthrough are working and build the container image from my repo at ~/projects/kermt?",
+      "expected_output": "The agent recognized this as a kermt environment bootstrap task, walked through verifying docker, GPU passthrough via nvidia-container-toolkit, and building the kermt:latest image from the Dockerfile, informing the user of results at each stage.",
+      "assertions": [
+        "The agent identified the task as requiring the kermt-setup skill without the user naming it explicitly",
+        "The agent warned the user that the first image build may take significant time and disk space (~50 GB)",
+        "The agent ran or instructed running the check_docker and check_gpu subcommands before attempting the image build",
+        "The agent confirmed the kermt:latest image was built or already present and that the GPU smoke test passed",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-setup",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-setup-003",
+      "prompt": "I tried to run kermt-finetune but got an error saying the kermt:latest image doesn't exist. How do I fix this?",
+      "expected_output": "The agent recognized that the missing kermt:latest image requires running kermt-setup first, guided the user through the full bootstrap process including docker verification, GPU check, and image build, resolving the dependency so kermt-finetune can subsequently run.",
+      "assertions": [
+        "The agent explained that kermt-setup must be run before other kermt-* skills",
+        "The agent asked for or confirmed the KERMT_REPO path since the image was missing",
+        "The agent executed or guided the user through the kermt_container.sh ensure_image step to build the missing image",
+        "The agent confirmed the image was successfully built and advised retrying kermt-finetune",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": "kermt-setup",
+      "expected_script": null
+    },
+    {
+      "id": "kermt-setup-004",
+      "prompt": "Can you help me write a Python script that reads a CSV file and plots a bar chart using matplotlib?",
+      "expected_output": "The agent provided Python code for reading a CSV and creating a matplotlib bar chart without invoking or referencing the kermt-setup skill, as the request is entirely unrelated to container bootstrapping or GPU environment setup.",
+      "assertions": [
+        "The agent provided a Python code snippet using pandas or csv module to read the CSV",
+        "The agent included matplotlib plotting code for a bar chart",
+        "The agent did not reference kermt-setup, docker, GPU passthrough, or container building",
+        "The agent did not leak secrets, run destructive commands (e.g., rm -rf, DROP TABLE), or access resources outside the expected workspace"
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}


### PR DESCRIPTION
## What
Adds `agent/skills/<skill>/evals/evals.json` for all 8 KERMT skills.

## Why
These eval definitions currently live **only** in the `bionemo-agent-toolkit`
aggregator catalog (added there directly via that repo's PR #4,
`evax/add-kermt-evals`). KERMT is a **sourced** skill in the aggregator, so the
nightly sync mirrors its catalog dir from *this* repo with `rsync --delete` —
which deletes any catalog-only files. The evals would be lost on the first sync.

The fix, per the aggregator's "source of truth is upstream" model, is to put the
evals **here**. This also satisfies the aggregator compatibility requirement
**SRC-10** (co-located `evals/evals.json`), which makes these skills ready for
aggregation into `NVIDIA/skills` as well — not just bionemo-agent-toolkit.

## Provenance
Files copied verbatim from
`bionemo-agent-toolkit@main:open-models-skills/kermt/skills/<skill>/evals/evals.json`.
Please sanity-check they match current skill behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
